### PR TITLE
Use defined speedtest server

### DIFF
--- a/app/Console/Commands/RunSpeedtest.php
+++ b/app/Console/Commands/RunSpeedtest.php
@@ -29,7 +29,13 @@ class RunSpeedtest extends Command
      */
     public function handle()
     {
-        ExecSpeedtest::dispatch();
+        $speedtest = [];
+
+        if ($this->argument('server')) {
+            $speedtest = array_merge($speedtest, ['ookla_server_id' => $this->argument('server')]);
+        }
+
+        ExecSpeedtest::dispatch(speedtest: $speedtest);
 
         $this->info('✅  added manual speedtest to the queue');
 

--- a/app/Jobs/ExecSpeedtest.php
+++ b/app/Jobs/ExecSpeedtest.php
@@ -33,7 +33,19 @@ class ExecSpeedtest implements ShouldQueue
      */
     public function handle()
     {
-        $process = new Process(['speedtest', '--accept-license', '--format=json']);
+        $args = [
+            'speedtest',
+            '--accept-license',
+            '--format=json',
+        ];
+
+        if (! blank($this->speedtest)) {
+            if (! blank($this->speedtest['ookla_server_id'])) {
+                $args = array_merge($args, ['--server-id='.$this->speedtest['ookla_server_id']]);
+            }
+        }
+
+        $process = new Process($args);
         $process->run();
 
         if (! $process->isSuccessful()) {


### PR DESCRIPTION
## Changelog

### Added
- Use defined speedtest server when running tests from the cli manually or scheduled jobs