### PR TITLE
Use config helper for debug policies

### DIFF
--- a/app/Policies/FailedJobPolicy.php
+++ b/app/Policies/FailedJobPolicy.php
@@ -11,6 +11,6 @@ class FailedJobPolicy
 
     public function viewAny(User $user): bool
 	{
-		return env('APP_DEBUG');
+		return config('app.debug');
 	}
 }

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -28,7 +28,7 @@ class FilamentServiceProvider extends ServiceProvider
     public function boot()
     {
         Logs::can(function (User $user) {
-            return env('APP_DEBUG');
+            return config('app.debug');
         });
 
         Filament::serving(function () {


### PR DESCRIPTION
## Changelog

### Fixed
- `500` that was thrown when accessing `env` variables directly in production, should use the `config()` helper instead