### PR TITLE
null safe model helper for chart data

### DIFF
--- a/app/Filament/Widgets/RecentJitterChart.php
+++ b/app/Filament/Widgets/RecentJitterChart.php
@@ -64,19 +64,19 @@ class RecentJitterChart extends LineChartWidget
             'datasets' => [
                 [
                     'label' => 'Download',
-                    'data' => $results->map(fn ($item) => json_decode($item->data)->download->latency->jitter),
+                    'data' => $results->map(fn ($item) => $item->getJitterData()['download']),
                     'borderColor' => '#0ea5e9',
                     'backgroundColor' => '#0ea5e9',
                 ],
                 [
                     'label' => 'Upload',
-                    'data' => $results->map(fn ($item) => json_decode($item->data)->upload->latency->jitter),
+                    'data' => $results->map(fn ($item) => $item->getJitterData()['upload']),
                     'borderColor' => '#8b5cf6',
                     'backgroundColor' => '#8b5cf6',
                 ],
                 [
                     'label' => 'Ping',
-                    'data' => $results->map(fn ($item) => json_decode($item->data)->ping->jitter),
+                    'data' => $results->map(fn ($item) => $item->getJitterData()['ping']),
                     'borderColor' => '#10b981',
                     'backgroundColor' => '#10b981',
                 ],

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -78,4 +78,15 @@ class Result extends Model
             'packet_loss' => (float) $data['packetLoss'] ?? null, // optional, because apparently the cli doesn't always have this metric
         ];
     }
+
+    public function getJitterData(): array
+    {
+        $data = json_decode($this->data, true);
+
+        return [
+            'download' => $data['download']['latency']['jitter'] ?? null,
+            'upload' => $data['upload']['latency']['jitter'] ?? null,
+            'ping' => $data['ping']['jitter'] ?? null,
+        ];
+    }
 }

--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -32,7 +32,7 @@ class FilamentServiceProvider extends ServiceProvider
             return true;
         });
 
-        FilamentVersions::addItem('Speedtest Tracker', 'v0.7.0');
+        FilamentVersions::addItem('Speedtest Tracker', 'v0.7.1');
 
         Filament::serving(function () {
             Filament::registerNavigationGroups([


### PR DESCRIPTION
## Changelog

### Fixed
- use null safe model helper for chart data, closes #217 