### PR TITLE
Fix favicon

### DIFF
--- a/config/filament.php
+++ b/config/filament.php
@@ -262,7 +262,7 @@ return [
     |
     */
 
-    'favicon' => '/img/speedtest-tracker-icon.png',
+    'favicon' => env('app.url').'/img/speedtest-tracker-icon.png',
 
     /*
     |--------------------------------------------------------------------------

--- a/config/filament.php
+++ b/config/filament.php
@@ -262,7 +262,7 @@ return [
     |
     */
 
-    'favicon' => public_path('img/speedtest-tracker-icon.png'),
+    'favicon' => '/img/speedtest-tracker-icon.png',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
The favicon was not displayed, because the request was made to `/var/www/html/public/img/speedtest-tracker-icon.png` and not `/img/speedtest-tracker-icon.png`