### PR TITLE
Percent change on stats widgets

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\RecentPingChart;
 use App\Filament\Widgets\RecentSpeedChart;
 use App\Filament\Widgets\StatsOverview;
 use App\Jobs\ExecSpeedtest;
+use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
@@ -14,7 +15,21 @@ use Filament\Pages\Dashboard as BasePage;
 
 class Dashboard extends BasePage
 {
+    public string $lastResult;
+
     protected static string $view = 'filament.pages.dashboard';
+
+    public function mount()
+    {
+        $result = Result::latest()
+            ->first();
+
+        $settings = new GeneralSettings();
+
+        $this->lastResult = $result
+            ? $result->created_at->timezone($settings->timezone)->format($settings->time_format)
+            :'never';
+    }
 
     protected function getActions(): array
     {
@@ -29,6 +44,12 @@ class Dashboard extends BasePage
     {
         return [
             StatsOverview::class,
+        ];
+    }
+
+    public function getFooterWidgets(): array
+    {
+        return [
             RecentSpeedChart::class,
             RecentPingChart::class,
             RecentJitterChart::class,

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -28,7 +28,7 @@ class Dashboard extends BasePage
 
         $this->lastResult = $result
             ? $result->created_at->timezone($settings->timezone)->format($settings->time_format)
-            :'never';
+            : 'never';
     }
 
     protected function getActions(): array

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -15,20 +15,27 @@ use Filament\Pages\Dashboard as BasePage;
 
 class Dashboard extends BasePage
 {
-    public string $lastResult;
+    public string $lastResult = 'never';
+
+    public int $resultsCount;
 
     protected static string $view = 'filament.pages.dashboard';
 
     public function mount()
     {
-        $result = Result::latest()
-            ->first();
+        $this->resultsCount = Result::count();
 
-        $settings = new GeneralSettings();
+        if ($this->resultsCount) {
+            $result = Result::latest()
+                ->first();
 
-        $this->lastResult = $result
-            ? $result->created_at->timezone($settings->timezone)->format($settings->time_format)
-            : 'never';
+            $settings = new GeneralSettings();
+
+            $this->lastResult = $result->created_at
+                    ->timezone($settings->timezone)
+                    ->format($settings->time_format);
+        }
+
     }
 
     protected function getActions(): array
@@ -42,6 +49,10 @@ class Dashboard extends BasePage
 
     public function getHeaderWidgets(): array
     {
+        if (! $this->resultsCount) {
+            return [];
+        }
+
         return [
             StatsOverview::class,
         ];
@@ -49,6 +60,10 @@ class Dashboard extends BasePage
 
     public function getFooterWidgets(): array
     {
+        if (! $this->resultsCount) {
+            return [];
+        }
+
         return [
             RecentSpeedChart::class,
             RecentPingChart::class,

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -39,17 +39,17 @@ class StatsOverview extends BaseWidget
         return [
             Card::make('Latest download', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->download)).'ps' : 'n/a')
                 ->icon('heroicon-o-download')
-                ->description( $downloadChange > 0 ? $downloadChange.'% faster' : abs($downloadChange).'% slower')
+                ->description($downloadChange > 0 ? $downloadChange.'% faster' : abs($downloadChange).'% slower')
                 ->descriptionIcon($downloadChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
                 ->color($downloadChange > 0 ? 'success' : 'danger'),
             Card::make('Latest upload', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->upload)).'ps' : 'n/a')
                 ->icon('heroicon-o-upload')
-                ->description( $uploadChange > 0 ? $uploadChange.'% faster' : abs($uploadChange).'% slower')
+                ->description($uploadChange > 0 ? $uploadChange.'% faster' : abs($uploadChange).'% slower')
                 ->descriptionIcon($uploadChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
                 ->color($uploadChange > 0 ? 'success' : 'danger'),
             Card::make('Latest ping', fn (): string => ! blank($result) ? round($result->ping, 2).'ms' : 'n/a')
                 ->icon('heroicon-o-clock')
-                ->description( $pingChange > 0 ? $pingChange.'% slower' : abs($pingChange).'% faster')
+                ->description($pingChange > 0 ? $pingChange.'% slower' : abs($pingChange).'% faster')
                 ->descriptionIcon($pingChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
                 ->color($pingChange > 0 ? 'danger' : 'success'),
         ];

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -15,14 +15,43 @@ class StatsOverview extends BaseWidget
 
         $settings = new GeneralSettings();
 
+        if (! $result) {
+            return [];
+        }
+
+        $previous = $result->previous();
+
+        if (! $previous) {
+            return [
+                Card::make('Latest download', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->download)).'ps' : 'n/a')
+                    ->icon('heroicon-o-download'),
+                Card::make('Latest upload', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->upload)).'ps' : 'n/a')
+                    ->icon('heroicon-o-upload'),
+                Card::make('Latest ping', fn (): string => ! blank($result) ? round($result->ping, 2).'ms' : 'n/a')
+                    ->icon('heroicon-o-clock'),
+            ];
+        }
+
+        $downloadChange = percentChange($result->download, $previous->download, 2);
+        $uploadChange = percentChange($result->upload, $previous->upload, 2);
+        $pingChange = percentChange($result->ping, $previous->ping, 2);
+
         return [
             Card::make('Latest download', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->download)).'ps' : 'n/a')
-                ->description(! blank($result) ? 'Tested at: '.$result->created_at->timezone($settings->timezone)->format($settings->time_format) : 'No tests')
-                ->icon('heroicon-o-download'),
+                ->icon('heroicon-o-download')
+                ->description( $downloadChange > 0 ? $downloadChange.'% faster' : abs($downloadChange).'% slower')
+                ->descriptionIcon($downloadChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
+                ->color($downloadChange > 0 ? 'success' : 'danger'),
             Card::make('Latest upload', fn (): string => ! blank($result) ? formatBits(formatBytesToBits($result->upload)).'ps' : 'n/a')
-                ->icon('heroicon-o-upload'),
+                ->icon('heroicon-o-upload')
+                ->description( $uploadChange > 0 ? $uploadChange.'% faster' : abs($uploadChange).'% slower')
+                ->descriptionIcon($uploadChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
+                ->color($uploadChange > 0 ? 'success' : 'danger'),
             Card::make('Latest ping', fn (): string => ! blank($result) ? round($result->ping, 2).'ms' : 'n/a')
-                ->icon('heroicon-o-clock'),
+                ->icon('heroicon-o-clock')
+                ->description( $pingChange > 0 ? $pingChange.'% slower' : abs($pingChange).'% faster')
+                ->descriptionIcon($pingChange > 0 ? 'heroicon-s-trending-up' : 'heroicon-s-trending-down')
+                ->color($pingChange > 0 ? 'danger' : 'success'),
         ];
     }
 }

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -89,4 +89,16 @@ class Result extends Model
             'ping' => $data['ping']['jitter'] ?? null,
         ];
     }
+
+    /**
+     * Return the previous test result .
+     *
+     * @return  self|null
+     */
+    public function previous()
+    {
+        return static::orderBy('id', 'desc')
+            ->where('id', '<', $this->id)
+            ->first();
+    }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -45,6 +45,15 @@ if (! function_exists('formatBytesToBits')) {
     }
 }
 
+if (! function_exists('percentChange')) {
+    function percentChange(float $dividend, float $divisor, int $precision = 0): float
+    {
+        $quotient = ($dividend - $divisor) / $divisor;
+
+        return number_format(round($quotient * 100, $precision), $precision);
+    }
+}
+
 if (! function_exists('absoluteDownloadThresholdFailed')) {
     function absoluteDownloadThresholdFailed(float $threshold, float $download): bool
     {

--- a/resources/views/filament/pages/dashboard.blade.php
+++ b/resources/views/filament/pages/dashboard.blade.php
@@ -1,1 +1,7 @@
-<x-filament::page />
+<x-filament::page>
+
+<div>
+    <p class="text-center text-sm">Last speedtest run at: <strong>{{ $lastResult }}</strong></p>
+</div>
+
+</x-filament::page>


### PR DESCRIPTION
## Changelog

### Added
- % changed for download, upload and ping stats vs. the previous result

### Changed
- moved the datetime of the last speedtest to below the stats widgets
- only render stats widgets and charts if there are actually results

## Previews

<img width="854" alt="image" src="https://user-images.githubusercontent.com/1144087/208509776-765202d0-c275-49dc-abfa-3030828972d3.png">
_Updated header widgets_