### PR TITLE
number_format returns a string

### DIFF
--- a/app/Providers/FilamentServiceProvider.php
+++ b/app/Providers/FilamentServiceProvider.php
@@ -32,7 +32,7 @@ class FilamentServiceProvider extends ServiceProvider
             return true;
         });
 
-        FilamentVersions::addItem('Speedtest Tracker', 'v0.9.0');
+        FilamentVersions::addItem('Speedtest Tracker', 'v0.9.1');
 
         Filament::serving(function () {
             Filament::registerNavigationGroups([

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -46,7 +46,7 @@ if (! function_exists('formatBytesToBits')) {
 }
 
 if (! function_exists('percentChange')) {
-    function percentChange(float $dividend, float $divisor, int $precision = 0): float
+    function percentChange(float $dividend, float $divisor, int $precision = 0): string
     {
         $quotient = ($dividend - $divisor) / $divisor;
 


### PR DESCRIPTION
## Changelog

### Fixed
- `percentChange()` function needs to return a string as the `number_format()` function does [php docs reference](https://www.php.net/manual/en/function.number-format.php), closes #255