### PR TITLE
Always format to megabits in recent speed chart

### DIFF
--- a/app/Filament/Widgets/RecentSpeedChart.php
+++ b/app/Filament/Widgets/RecentSpeedChart.php
@@ -49,7 +49,7 @@ class RecentSpeedChart extends LineChartWidget
             'datasets' => [
                 [
                     'label' => 'Download',
-                    'data' => $results->map(fn ($item) => formatBits(formatBytesToBits($item->download), 2, false)),
+                    'data' => $results->map(fn ($item) => roundBytesToMegabits($item->download)),
                     'borderColor' => '#0ea5e9',
                     'backgroundColor' => '#0ea5e9',
                     'fill' => false,
@@ -58,7 +58,7 @@ class RecentSpeedChart extends LineChartWidget
                 ],
                 [
                     'label' => 'Upload',
-                    'data' => $results->map(fn ($item) => formatBits(formatBytesToBits($item->upload), 2, false)),
+                    'data' => $results->map(fn ($item) => roundBytesToMegabits($item->upload)),
                     'borderColor' => '#8b5cf6',
                     'backgroundColor' => '#8b5cf6',
                     'fill' => false,

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -45,6 +45,21 @@ if (! function_exists('formatBytesToBits')) {
     }
 }
 
+if (! function_exists('roundBytesToMegabits')) {
+    function roundBytesToMegabits(int $bytes)
+    {
+        if ($bytes > 0) {
+            $bits = formatBytesToBits($bytes);
+            $megabit_exponent = 2;
+            $precision = 2;
+
+            return round($bits / pow(1000, $megabit_exponent), $precision);
+        }
+
+        return 0;
+    }
+}
+
 if (! function_exists('percentChange')) {
     function percentChange(float $dividend, float $divisor, int $precision = 0): string
     {


### PR DESCRIPTION
Addresses #232

This change unconditionally formats the recent speed chart in megabits instead of using the "formatBits" function that uses floor function to format the nearest whole number.

## Before
Before the graph would send a result in gigabits to a lower y-axis value 
<img width="1255" alt="Gigabit example - before" src="https://user-images.githubusercontent.com/9521010/209449349-d241492d-4ad3-468c-bb4b-ef08425685d6.png">

## After
Now the graph correctly displays gigabits converted to megabits

<img width="1252" alt="Gigabit example - after" src="https://user-images.githubusercontent.com/9521010/209449358-e5730519-8538-41f5-8bbc-0762a10e0e90.png">

### With Kilobits
This resolves the megabit to kilobit issue as well.

<img width="1246" alt="Kilobit example - after" src="https://user-images.githubusercontent.com/9521010/209449366-f2c63e66-886c-4f59-bd0d-cd1252139250.png">
