### PR TITLE
Add cron expression form validation

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages\Settings;
 
+use App\Rules\ValidCronExpression;
 use App\Settings\GeneralSettings;
 use Filament\Forms\Components\Card;
 use Filament\Forms\Components\Grid;
@@ -64,6 +65,7 @@ class GeneralPage extends SettingsPage
                         Section::make('Speedtest Settings')
                             ->schema([
                                 TextInput::make('speedtest_schedule')
+                                    ->rules([new ValidCronExpression()])
                                     ->helperText('Leave empty to disable the schedule. You can also use the cron expression generator [HERE](https://crontab.cronhub.io/) to help you make schedules.')
                                     ->nullable()
                                     ->columnSpan(1),

--- a/app/Rules/ValidCronExpression.php
+++ b/app/Rules/ValidCronExpression.php
@@ -2,8 +2,8 @@
 
 namespace App\Rules;
 
-use Illuminate\Contracts\Validation\InvokableRule;
 use Cron\CronExpression;
+use Illuminate\Contracts\Validation\InvokableRule;
 
 class ValidCronExpression implements InvokableRule
 {
@@ -19,8 +19,8 @@ class ValidCronExpression implements InvokableRule
     {
         $is_valid = CronExpression::isValidExpression($value);
 
-        if (!$is_valid) {
-            $fail("Cron expression is not valid");
+        if (! $is_valid) {
+            $fail('Cron expression is not valid');
         }
     }
 }

--- a/app/Rules/ValidCronExpression.php
+++ b/app/Rules/ValidCronExpression.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\InvokableRule;
+use Cron\CronExpression;
+
+class ValidCronExpression implements InvokableRule
+{
+    /**
+     * Validates a string cron expression is correct
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @param  \Closure(string): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @return void
+     */
+    public function __invoke($attribute, $value, $fail)
+    {
+        $is_valid = CronExpression::isValidExpression($value);
+
+        if (!$is_valid) {
+            $fail("Cron expression is not valid");
+        }
+    }
+}


### PR DESCRIPTION
Using the [CronExpression](https://github.com/dragonmantank/cron-expression) library, this addition ensures that a cron expression is valid in settings before allowing the user to save it.

Addresses #278

### Other notes

The `ValidCronExpression` [Laravel rule](https://laravel.com/docs/9.x/validation#custom-validation-rules) was generated using the following command

```sh
php artisan make:rule ValidCronExpression --invokable
```

## Before

Invalid cron expressions are saved without an error.

<img width="699" alt="Screenshot 2022-12-29 141847" src="https://user-images.githubusercontent.com/9521010/210007798-8257a48f-90d2-46d1-b092-5ab0ac71cac1.png">

## After
On Save, invalid cron expressions are not saved and the error is reflected in a UI message.

<img width="460" alt="Screenshot_20221229_022350" src="https://user-images.githubusercontent.com/9521010/210007851-d9d17fe3-bbe5-4aee-927f-184040d104f2.png">
