### PR TITLE
delete speedtest results from the UI

### DIFF
--- a/app/Filament/Pages/DeleteData.php
+++ b/app/Filament/Pages/DeleteData.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Jobs\DeleteResultsData;
+use Filament\Notifications\Notification;
+use Filament\Pages\Actions\Action;
+use Filament\Pages\Page;
+
+class DeleteData extends Page
+{
+    protected static ?string $navigationGroup = 'System';
+
+    protected static ?string $navigationIcon = 'heroicon-o-trash';
+
+    protected static ?int $navigationSort = 2;
+
+    protected static ?string $slug = 'system/delete-data';
+
+    protected static string $view = 'filament.pages.delete-data';
+
+    protected ?string $maxContentWidth = '3xl';
+
+    public function getActions(): array
+    {
+        return [
+            Action::make('delete')
+                ->color('danger')
+                ->icon('heroicon-o-trash')
+                ->action(fn () => $this->deleteData())
+                ->requiresConfirmation()
+                ->modalHeading('Confirmation')
+                ->modalSubheading('Are you really-really-really sure you want to do this?')
+                ->modalContent(view('filament.pages.modals.delete-results-data-confirmation'))
+                ->modalButton('Yes, I\'m sure'),
+        ];
+    }
+
+    protected function deleteData()
+    {
+        DeleteResultsData::dispatch();
+
+        Notification::make()
+            ->title('Deleting speedtest results data')
+            ->body('The job has been added to the queue and will be completed shortly.')
+            ->warning()
+            ->send();
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -24,9 +24,13 @@ class UserResource extends Resource
 {
     protected static ?string $model = User::class;
 
+    protected static ?string $navigationGroup = 'System';
+
     protected static ?string $navigationIcon = 'heroicon-o-collection';
 
-    protected static ?string $navigationGroup = 'System';
+    protected static ?int $navigationSort = 0;
+
+    protected static ?string $slug = 'system/users';
 
     public static function form(Form $form): Form
     {

--- a/app/Jobs/DeleteResultsData.php
+++ b/app/Jobs/DeleteResultsData.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Result;
+use App\Models\User;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class DeleteResultsData implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $count = Result::count();
+
+        try {
+            DB::table('results')->truncate();
+        } catch (\Throwable $th) {
+            //throw $th;
+
+            return 0;
+        }
+
+        $recipient = User::first();
+
+        Notification::make()
+            ->title('Speedtest results deleted')
+            ->body($count.' speedtest results were deleted from the database.')
+            ->success()
+            ->sendToDatabase($recipient);
+    }
+}

--- a/app/Jobs/DeleteResultsData.php
+++ b/app/Jobs/DeleteResultsData.php
@@ -35,15 +35,19 @@ class DeleteResultsData implements ShouldQueue, ShouldBeUnique
     {
         $count = Result::count();
 
+        $recipient = User::first();
+
         try {
             DB::table('results')->truncate();
         } catch (\Throwable $th) {
-            //throw $th;
+            Notification::make()
+                ->title('There was a problem deleting speedtest results data')
+                ->body('Check the logs.')
+                ->success()
+                ->sendToDatabase($recipient);
 
             return 0;
         }
-
-        $recipient = User::first();
 
         Notification::make()
             ->title('Speedtest results deleted')

--- a/app/Jobs/DeleteResultsData.php
+++ b/app/Jobs/DeleteResultsData.php
@@ -43,7 +43,7 @@ class DeleteResultsData implements ShouldQueue, ShouldBeUnique
             Notification::make()
                 ->title('There was a problem deleting speedtest results data')
                 ->body('Check the logs.')
-                ->success()
+                ->danger()
                 ->sendToDatabase($recipient);
 
             return 0;

--- a/resources/views/filament/pages/delete-data.blade.php
+++ b/resources/views/filament/pages/delete-data.blade.php
@@ -1,0 +1,22 @@
+<x-filament::page>
+    <x-filament::card>
+        <x-slot name="header">
+            <h2 class="text-lg font-bold -tracking-tight">Results Data</h2>
+        </x-slot>
+
+        <div class="space-y-4">
+            <div>
+                <p>Deleting results data will remove all speedtest results from the database, this cannot be undone.</p>
+            </div>
+
+            <div>
+                <p>The following <span class="underline">will not</span> be reset by clearing results data.</p>
+
+                <ul class="list-disc list-inside mt-2">
+                    <li>- Settings including general settings, notification settings and threshold settings.</li>
+                    <li>- Integrations and data sent to external data destinations like InfluxDB.</li>
+                </ul>
+            </div>
+        </div>
+    </x-filament::card>
+</x-filament::page>

--- a/resources/views/filament/pages/modals/delete-results-data-confirmation.blade.php
+++ b/resources/views/filament/pages/modals/delete-results-data-confirmation.blade.php
@@ -1,0 +1,5 @@
+<div>
+    <div class="space-y-4">
+        <p>This will delete all speedtest results data from the database, this cannot be undone. You have been warned.</p>
+    </div>
+</div>


### PR DESCRIPTION
## Changelog

### Added
- delete speedtest results data from the UI, closes #293 

## Previews
![image](https://user-images.githubusercontent.com/1144087/212220146-1925f714-2e68-4c98-9228-fcbf9df87848.png)
_Delete data page preview_