### PR TITLE
[Bugfix] missing general settings class import

### DIFF
--- a/app/Filament/Pages/Settings/ThresholdsPage.php
+++ b/app/Filament/Pages/Settings/ThresholdsPage.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Pages\Settings;
 
+use App\Settings\GeneralSettings;
 use App\Settings\ThresholdSettings;
 use Closure;
 use Filament\Forms\Components\Card;

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -6,7 +6,7 @@ return [
     /**
      * Build information
      */
-    'build_date' => Carbon::parse('2023-03-06'),
+    'build_date' => Carbon::parse('2023-03-07'),
 
-    'build_version' => '0.11.4',
+    'build_version' => '0.11.5',
 ];


### PR DESCRIPTION
## Changelog

### Fixed
- missing `GeneralSettings()` class import on `ThresholdsPage`.