### PR TITLE
Bugfix: API download speed is reported as upload speed

### DIFF
--- a/app/Http/Controllers/API/Speedtest/GetLatestController.php
+++ b/app/Http/Controllers/API/Speedtest/GetLatestController.php
@@ -30,7 +30,7 @@ class GetLatestController extends Controller
                 'id' => $latest->id,
                 'ping' => $latest->ping,
                 'download' => ! blank($latest->download) ? toBits(convertSize($latest->download)) : null,
-                'upload' => ! blank($latest->download) ? toBits(convertSize($latest->download)) : null,
+                'upload' => ! blank($latest->upload) ? toBits(convertSize($latest->upload)) : null,
                 'server_id' => $latest->server_id,
                 'server_host' => $latest->server_host,
                 'server_name' => $latest->server_name,


### PR DESCRIPTION
Fixed the bug that the download speed in the API is incorrectly reported as upload speed

See https://github.com/alexjustesen/speedtest-tracker/issues/81#issuecomment-1466055593

![image](https://user-images.githubusercontent.com/11020494/224715018-a2f069e9-e43a-443d-bed3-e605e5e1367d.png)
