### PR TITLE
Move fix permissions section of laravel-automations

### DIFF
--- a/docker/deploy/etc/s6-overlay/scripts/laravel-automations
+++ b/docker/deploy/etc/s6-overlay/scripts/laravel-automations
@@ -7,6 +7,14 @@ echo ""
 echo "🐇  Configuring Speedtest Tracker..."
 echo ""
 
+# Fix permissions
+echo "🔒  Fixing app path file permissions..."
+chmod -R 755 /config
+chown -R webuser:webgroup /config
+chown -R webuser:webgroup $WEBUSER_HOME
+echo "✅  Permissions fixed."
+echo ""
+
 if [ ${DB_CONNECTION:="sqlite"} == "sqlite" ]; then
     # Check for database
     if [ ! -f /config/database.sqlite ]; then
@@ -78,14 +86,6 @@ else
     echo "✅  App key generated."
 fi
 
-echo ""
-
-# Fix permissions
-echo "🔒  Fixing app path file permissions..."
-chmod -R 755 /config
-chown -R webuser:webgroup /config
-chown -R webuser:webgroup $WEBUSER_HOME
-echo "✅  Permissions fixed."
 echo ""
 
 # create storage symlink


### PR DESCRIPTION
Appears to fix alexjustesen/speedtest-tracker#498 where it's trying to write to `/config` before `webuser` has been permissioned.