### PR TITLE
fixing bourne shell syntax error

### DIFF
--- a/docker/deploy/etc/s6-overlay/scripts/laravel-automations
+++ b/docker/deploy/etc/s6-overlay/scripts/laravel-automations
@@ -15,7 +15,7 @@ chown -R webuser:webgroup $WEBUSER_HOME
 echo "✅  Permissions fixed."
 echo ""
 
-if [ ${DB_CONNECTION:="sqlite"} == "sqlite" ]; then
+if [ ${DB_CONNECTION:="sqlite"} = "sqlite" ]; then
     # Check for database
     if [ ! -f /config/database.sqlite ]; then
         echo "🙄  SQLite database not found, creating..."


### PR DESCRIPTION
This resolves the syntax error in the entrypoint.

Before:
```
speedtest-tracker       | 
speedtest-tracker       | 
speedtest-tracker       | 🐇  Configuring Speedtest Tracker...
speedtest-tracker       | 🙄  Config file not found, creating...
speedtest-tracker       | /entrypoint: 11: [: mysql: unexpected operator
speedtest-tracker       | ⏳  Generating app key...
. . .
```

After:
```
speedtest-tracker       | 📦  Linking storage...
speedtest-tracker       | 💰  Building the cache...
speedtest-tracker       | 🚛  Migrating the database...
speedtest-tracker       | 🔑  Fixing permissions...
. . .
```
