### PR TITLE
Fix spelling errors found on notification page

### DIFF
--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -70,7 +70,7 @@ class NotificationPage extends SettingsPage
                                             Fieldset::make('Triggers')
                                                 ->schema([
                                                     Toggle::make('database_on_speedtest_run')
-                                                        ->label('Notify on every speetest run')
+                                                        ->label('Notify on every speedtest run')
                                                         ->columnSpan(2),
                                                     Toggle::make('database_on_threshold_failure')
                                                         ->label('Notify on threshold failures')
@@ -98,7 +98,7 @@ class NotificationPage extends SettingsPage
                                             Fieldset::make('Triggers')
                                                 ->schema([
                                                     Toggle::make('mail_on_speedtest_run')
-                                                        ->label('Notify on every speetest run')
+                                                        ->label('Notify on every speedtest run')
                                                         ->columnSpan(2),
                                                     Toggle::make('mail_on_threshold_failure')
                                                         ->label('Notify on threshold failures')
@@ -138,7 +138,7 @@ class NotificationPage extends SettingsPage
                                             Fieldset::make('Triggers')
                                                 ->schema([
                                                     Toggle::make('telegram_on_speedtest_run')
-                                                        ->label('Notify on every speetest run')
+                                                        ->label('Notify on every speedtest run')
                                                         ->columnSpan(2),
                                                     Toggle::make('telegram_on_threshold_failure')
                                                         ->label('Notify on threshold failures')

--- a/resources/views/filament/forms/notifications-helptext.blade.php
+++ b/resources/views/filament/forms/notifications-helptext.blade.php
@@ -1,6 +1,6 @@
 <div>
     <p>
-        💡 Did you know, when a notification is trigged it's sent to channels.
+        💡 Did you know, when a notification is triggered it's sent to channels.
         Each channel can be configured separately to have the notification sent to a specific destination.
     </p>
 </div>


### PR DESCRIPTION
# Description

Fixing some spelling errors found on the notification page.

## Changelog

### Fixed
- speetest -> spee**d**test
- trigged -> trigg**er**ed
