### PR TITLE
[Bug] added back deleted telegram notification class

### DIFF
--- a/app/Telegram/TelegramNotification.php
+++ b/app/Telegram/TelegramNotification.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Telegram;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+use NotificationChannels\Telegram\TelegramMessage;
+
+class TelegramNotification extends Notification
+{
+    use Queueable;
+
+    protected $message;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct($message)
+    {
+        $this->message = $message;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['telegram'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toTelegram($notifiable)
+    {
+        return TelegramMessage::create()
+            ->to($notifiable->routes['telegram_chat_id'])
+            ->content($this->message);
+    }
+}


### PR DESCRIPTION
## Changelog

### Fixed
- Telegram notifications were accidently deleted in the Laravel 10 upgrade, 

closes #582 
closes #585 