### PR TITLE
[Feature] Polling config for dashboard and results

### DIFF
--- a/app/Filament/Resources/ResultResource/Pages/ListResults.php
+++ b/app/Filament/Resources/ResultResource/Pages/ListResults.php
@@ -12,7 +12,7 @@ class ListResults extends ListRecords
 
     protected function getTablePollingInterval(): ?string
     {
-        return '5s';
+        return config('speedtest.results_polling');
     }
 
     protected function getMaxContentWidth(): string

--- a/app/Filament/Widgets/RecentJitterChart.php
+++ b/app/Filament/Widgets/RecentJitterChart.php
@@ -14,6 +14,11 @@ class RecentJitterChart extends LineChartWidget
 
     public ?string $filter = '24h';
 
+    protected function getPollingInterval(): ?string
+    {
+        return config('speedtest.dashboard_polling');
+    }
+
     protected function getHeading(): string
     {
         return 'Jitter';

--- a/app/Filament/Widgets/RecentPingChart.php
+++ b/app/Filament/Widgets/RecentPingChart.php
@@ -14,6 +14,11 @@ class RecentPingChart extends LineChartWidget
 
     public ?string $filter = '24h';
 
+    protected function getPollingInterval(): ?string
+    {
+        return config('speedtest.dashboard_polling');
+    }
+
     protected function getHeading(): string
     {
         return 'Ping (ms)';

--- a/app/Filament/Widgets/RecentSpeedChart.php
+++ b/app/Filament/Widgets/RecentSpeedChart.php
@@ -14,6 +14,11 @@ class RecentSpeedChart extends LineChartWidget
 
     public ?string $filter = '24h';
 
+    protected function getPollingInterval(): ?string
+    {
+        return config('speedtest.dashboard_polling');
+    }
+
     protected function getHeading(): string
     {
         return 'Download / Upload';

--- a/app/Filament/Widgets/StatsOverview.php
+++ b/app/Filament/Widgets/StatsOverview.php
@@ -9,6 +9,11 @@ use Filament\Widgets\StatsOverviewWidget\Card;
 
 class StatsOverview extends BaseWidget
 {
+    protected function getPollingInterval(): ?string
+    {
+        return config('speedtest.dashboard_polling');
+    }
+
     protected function getCards(): array
     {
         $result = Result::latest()->first();

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -9,4 +9,11 @@ return [
     'build_date' => Carbon::parse('2023-05-12'),
 
     'build_version' => '0.11.16',
+
+    /**
+     * Polling
+     */
+    'dashboard_polling' => env('DASHBOARD_POLLING', '5s'),
+
+    'results_polling' => env('RESULTS_POLLING', '5s'),
 ];


### PR DESCRIPTION
# Description

This PR introduces polling configuration settings via environment variables. `DASHBOARD_POLLING` and `RESULTS_POLLING` default to `5s` and can be disabled by passing `false` as the environment variables to the container. This also accepts a string if you want to extend the polling length (example: `60s`).

```
-e DASHBOARD_POLLING=false
-e RESULTS_POLLING=false
```

## Changelog

### Added
- polling config