### PR TITLE
[Feature] Reset user password command

### DIFF
--- a/app/Console/Commands/ResetUserPassword.php
+++ b/app/Console/Commands/ResetUserPassword.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Hash;
+
+class ResetUserPassword extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:reset-user-password
+                            {email : The email address of the user}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Reset the password for a user\'s account.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $user = User::firstWhere('email', $this->argument('email'));
+
+        if (! $user) {
+            // couldn't find the user so should fail.
+            $this->error('Could not find a user with the email address of '.$$this->argument('email'));
+
+            Command::FAILURE;
+        }
+
+        $password = $this->secret('What is the password?');
+
+        $user->update([
+            'password' => Hash::make($password),
+        ]);
+
+        Command::SUCCESS;
+    }
+}

--- a/app/Jobs/DeleteResultsData.php
+++ b/app/Jobs/DeleteResultsData.php
@@ -13,7 +13,7 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 
-class DeleteResultsData implements ShouldQueue, ShouldBeUnique
+class DeleteResultsData implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 

--- a/app/Jobs/ExecSpeedtest.php
+++ b/app/Jobs/ExecSpeedtest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class ExecSpeedtest implements ShouldQueue, ShouldBeUnique
+class ExecSpeedtest implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,8 @@ use Illuminate\Support\Facades\Route;
 
 Route::redirect('/', '/admin');
 
+Route::redirect('/login', '/admin/login');
+
 if (app()->isLocal()) {
     require __DIR__.'/test.php';
 }


### PR DESCRIPTION
# Description

This PR introduces a new CLI command to reset a user's password by using `app:reset-user-password` and providing the email address of the user as an argument. Example `app:reset-user-password admin@example.com`. Closes #718 

## Changelog

### Added
- `app:reset-user-password` command

### Changed
- redirect `/login` to `/admin/login`
