### PR TITLE
[Feature] Refactored format data for InfluxDB

### DIFF
--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -83,7 +83,7 @@ class Result extends Model
             'ping' => $this?->ping,
             'download' => $this?->download,
             'upload' => $this?->upload,
-            'download_bits' => $this->download ? $this->download * 8: null,
+            'download_bits' => $this->download ? $this->download * 8 : null,
             'upload_bits' => $this->upload ? $this->upload * 8 : null,
             'ping_jitter' => Arr::get($data, 'ping.jitter'),
             'download_jitter' => Arr::get($data, 'download.latency.jitter'),

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -92,6 +92,7 @@ class Result extends Model
             'server_host' => $this?->server_host,
             'server_name' => $this?->server_name,
             'scheduled' => $this->scheduled,
+            'successful' => $this->successful,
             'packet_loss'=> Arr::get($data, 'packetLoss'),
         ];
     }

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -77,7 +77,6 @@ class Result extends Model
     {
         $data = json_decode($this->data, true);
 
-        // New hotness
         return [
             'id' => $this->id,
             'ping' => $this?->ping,
@@ -93,7 +92,7 @@ class Result extends Model
             'server_name' => $this?->server_name,
             'scheduled' => $this->scheduled,
             'successful' => $this->successful,
-            'packet_loss'=> Arr::get($data, 'packetLoss'),
+            'packet_loss' => Arr::get($data, 'packetLoss'),
         ];
     }
 

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Events\ResultCreated;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 class Result extends Model
 {
@@ -76,21 +77,22 @@ class Result extends Model
     {
         $data = json_decode($this->data, true);
 
+        // New hotness
         return [
-            'id' => (int) $this->id,
-            'ping' => (float) $this->ping,
-            'download' => (int) $this->download,
-            'upload' => (int) $this->upload,
-            'download_bits' => (int) $this->download * 8,
-            'upload_bits' => (int) $this->upload * 8,
-            'ping_jitter' => (float) $data['ping']['jitter'] ?? null,
-            'download_jitter' => (float) $data['download']['latency']['jitter'] ?? null,
-            'upload_jitter' => (float) $data['upload']['latency']['jitter'] ?? null,
-            'server_id' => (int) $this->server_id,
-            'server_host' => $this->server_host,
-            'server_name' => $this->server_name,
+            'id' => $this->id,
+            'ping' => $this?->ping,
+            'download' => $this?->download,
+            'upload' => $this?->upload,
+            'download_bits' => $this->download ? $this->download * 8: null,
+            'upload_bits' => $this->upload ? $this->upload * 8 : null,
+            'ping_jitter' => Arr::get($data, 'ping.jitter'),
+            'download_jitter' => Arr::get($data, 'download.latency.jitter'),
+            'upload_jitter' => Arr::get($data, 'upload.latency.jitter'),
+            'server_id' => $this?->server_id,
+            'server_host' => $this?->server_host,
+            'server_name' => $this?->server_name,
             'scheduled' => $this->scheduled,
-            'packet_loss' => array_key_exists('packetLoss', $data) ? (float) $data['packetLoss'] : null, // optional, because apparently the cli doesn't always have this metric
+            'packet_loss'=> Arr::get($data, 'packetLoss'),
         ];
     }
 


### PR DESCRIPTION
# Description

This PR refactors InfluxDB method to prevent array key or value not found errors. This will also correctly format data that is missing as `null` instead of `0`.

## Changelog

### Added
- `successful` attribute

### Changed
- if data is missing return `null` not `0`
- refactored data payload for InfluxDB

### Fixed
- #549