### PR TITLE
[Bug] Settings page authorization

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -25,10 +25,10 @@ class GeneralPage extends SettingsPage
 
     protected static string $settings = GeneralSettings::class;
 
-    public function mount(): void
-    {
-        abort_unless(auth()->user()->is_admin, 403);
-    }
+    // public function mount(): void
+    // {
+    //     abort_unless(auth()->user()->is_admin, 403);
+    // }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -25,10 +25,12 @@ class GeneralPage extends SettingsPage
 
     protected static string $settings = GeneralSettings::class;
 
-    // public function mount(): void
-    // {
-    //     abort_unless(auth()->user()->is_admin, 403);
-    // }
+    public function mount(): void
+    {
+        abort_unless(auth()->user()->is_admin, 403);
+
+        $this->fillForm();
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/InfluxDbPage.php
+++ b/app/Filament/Pages/Settings/InfluxDbPage.php
@@ -21,10 +21,12 @@ class InfluxDbPage extends SettingsPage
 
     protected static string $settings = InfluxDbSettings::class;
 
-    // public function mount(): void
-    // {
-    //     abort_unless(auth()->user()->is_admin, 403);
-    // }
+    public function mount(): void
+    {
+        abort_unless(auth()->user()->is_admin, 403);
+
+        $this->fillForm();
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/InfluxDbPage.php
+++ b/app/Filament/Pages/Settings/InfluxDbPage.php
@@ -21,10 +21,10 @@ class InfluxDbPage extends SettingsPage
 
     protected static string $settings = InfluxDbSettings::class;
 
-    public function mount(): void
-    {
-        abort_unless(auth()->user()->is_admin, 403);
-    }
+    // public function mount(): void
+    // {
+    //     abort_unless(auth()->user()->is_admin, 403);
+    // }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -29,10 +29,10 @@ class NotificationPage extends SettingsPage
 
     protected static string $settings = NotificationSettings::class;
 
-    public function mount(): void
-    {
-        abort_unless(auth()->user()->is_admin, 403);
-    }
+    // public function mount(): void
+    // {
+    //     abort_unless(auth()->user()->is_admin, 403);
+    // }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -29,10 +29,12 @@ class NotificationPage extends SettingsPage
 
     protected static string $settings = NotificationSettings::class;
 
-    // public function mount(): void
-    // {
-    //     abort_unless(auth()->user()->is_admin, 403);
-    // }
+    public function mount(): void
+    {
+        abort_unless(auth()->user()->is_admin, 403);
+
+        $this->fillForm();
+    }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/ThresholdsPage.php
+++ b/app/Filament/Pages/Settings/ThresholdsPage.php
@@ -21,10 +21,10 @@ class ThresholdsPage extends SettingsPage
 
     protected static string $settings = ThresholdSettings::class;
 
-    public function mount(): void
-    {
-        abort_unless(auth()->user()->is_admin, 403);
-    }
+    // public function mount(): void
+    // {
+    //     abort_unless(auth()->user()->is_admin, 403);
+    // }
 
     public static function shouldRegisterNavigation(): bool
     {

--- a/app/Filament/Pages/Settings/ThresholdsPage.php
+++ b/app/Filament/Pages/Settings/ThresholdsPage.php
@@ -21,10 +21,12 @@ class ThresholdsPage extends SettingsPage
 
     protected static string $settings = ThresholdSettings::class;
 
-    // public function mount(): void
-    // {
-    //     abort_unless(auth()->user()->is_admin, 403);
-    // }
+    public function mount(): void
+    {
+        abort_unless(auth()->user()->is_admin, 403);
+
+        $this->fillForm();
+    }
 
     public static function shouldRegisterNavigation(): bool
     {


### PR DESCRIPTION
# Description

This PR fixes a [bug](https://github.com/filamentphp/filament/issues/8555) found that required calling `$this->FillForm()` again when using `mount()` to authorize a settings page.

## Changelog

### Fixed

- settings forms not being filled when authorizing the page