### PR TITLE
[Bugfix] Clear cache on startup and default cache driver to file

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -15,7 +15,7 @@ return [
     |
     */
 
-    'default' => env('CACHE_DRIVER', 'database'),
+    'default' => env('CACHE_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------

--- a/docker/deploy/etc/s6-overlay/scripts/laravel-automations
+++ b/docker/deploy/etc/s6-overlay/scripts/laravel-automations
@@ -16,6 +16,12 @@ chown -R webuser:webgroup $WEBUSER_HOME/storage
 echo "✅  Permissions fixed."
 echo ""
 
+# Build cache
+echo "🧹  Clearing any previous caches..."
+s6-setuidgid webuser php $WEBUSER_HOME/artisan optimize:clear --no-ansi -q
+echo "✅  Cache cleared."
+echo ""
+
 if [ ${DB_CONNECTION:="sqlite"} = "sqlite" ]; then
     # create symlinks
     echo "🔗  Creating database symlink..."


### PR DESCRIPTION
# Description

This PR changes the default cache driver to `file` system as it is more performant than the `database` driver and fine for most cases. Also the cache will now be cleared on startup before checking if an app key exists.

## Changelog

### Added

- [Caching](https://docs.speedtest-tracker.dev/other/caching) section to the docs

### Changed

- changed the default cache driver to the `file` system

### Fixed

- clear existing cache on startup to avoid "app key missing" errors, closes #839 
