### PR TITLE
[Feature] Latest result timestamp on dashboard

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -12,8 +12,17 @@ class HomeController extends Controller
      */
     public function __invoke(Request $request)
     {
-        $hasResults = Result::count() > 0;
+        $latestResult = Result::query()
+            ->select(['id', 'ping', 'download', 'upload', 'successful' ,'created_at'])
+            ->latest()
+            ->first();
 
-        return view($hasResults ? 'dashboard' : 'get-started');
+        if (! $latestResult) {
+            return view('get-started');
+        }
+
+        return view('dashboard', [
+            'latestResult' => $latestResult,
+        ]);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -13,7 +13,7 @@ class HomeController extends Controller
     public function __invoke(Request $request)
     {
         $latestResult = Result::query()
-            ->select(['id', 'ping', 'download', 'upload', 'successful' ,'created_at'])
+            ->select(['id', 'ping', 'download', 'upload', 'successful', 'created_at'])
             ->latest()
             ->first();
 

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -4,6 +4,12 @@
             @livewire(\App\Filament\Widgets\StatsOverviewWidget::class)
         </div>
 
+        @if ($latestResult)
+            <div class="text-sm font-semibold leading-6 text-center col-span-full sm:text-base">
+                Latest result: {{ $latestResult?->created_at->diffForHumans() }}
+            </div>
+        @endif
+
         <div class="col-span-full">
             @livewire(\App\Filament\Widgets\RecentSpeedChartWidget::class)
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,7 +14,8 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', HomeController::class);
+Route::get('/', HomeController::class)
+    ->name('home');
 
 Route::get('/login', function () {
     return redirect('/admin/login');


### PR DESCRIPTION
# Description

This PR adds back the latest result timestamp on the dashboard.

## Changelog

### Added

- latest result timestamp to the public dashboard, closes #840 

### Fixed

- missing `home` route name
