### PR TITLE
Added public dashboard enabled setting to general settings

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -114,6 +114,18 @@ class GeneralPage extends SettingsPage
                                 'default' => 1,
                                 'md' => 2,
                             ]),
+
+                        Forms\Components\Section::make('Public Dashboard Settings')
+                            ->schema([
+                                Forms\Components\Toggle::make('public_dashboard_enabled')
+                                    ->label('Enable')
+                                    ->columnSpan(2),
+                            ])
+                            ->compact()
+                            ->columns([
+                                'default' => 1,
+                                'md' => 2,
+                            ]),
                     ])
                     ->columnSpan('full'),
             ]);

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Illuminate\Http\Request;
 
 class HomeController extends Controller
@@ -12,6 +13,11 @@ class HomeController extends Controller
      */
     public function __invoke(Request $request)
     {
+        $settings = new GeneralSettings();
+        if (!$settings->public_dashboard_enabled) {
+            return redirect()->route('filament.admin.auth.login');
+        }
+
         $latestResult = Result::query()
             ->select(['id', 'ping', 'download', 'upload', 'successful', 'created_at'])
             ->latest()

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -19,6 +19,8 @@ class GeneralSettings extends Settings
 
     public string $timezone;
 
+    public bool $public_dashboard_enabled;
+
     public static function group(): string
     {
         return 'general';

--- a/database/settings/2023_10_07_113220_add_public_dashboard_enabled_to_general_settings.php
+++ b/database/settings/2023_10_07_113220_add_public_dashboard_enabled_to_general_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.public_dashboard_enabled', true);
+    }
+};


### PR DESCRIPTION
Fixes #855 

## Changelog

### Added

- Enable/Disable Public Dashboard setting to general settings (default: enabled)
- If public dashboard is disabled -> redirect to login (as it was before public dashboard was introduced)

## Screenshots

![settings](https://github.com/alexjustesen/speedtest-tracker/assets/5730574/c861a7a4-90c2-4ea0-b315-2b0b903b255b)
