### PR TITLE
[Chore] Build and publish dev image workflow

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-      - cron: '0 4 * * *'
+    - cron: '0 4 * * *'
 
 env:
   PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,53 @@
+name: Build and push dev Docker images
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+      - cron: '0 4 * * *'
+
+env:
+  PLATFORMS: linux/amd64,linux/arm64,linux/arm/v7
+
+jobs:
+  build_and_push_image:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=dev
+
+      - name: Build and push Docker images
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          platforms: ${{ env.PLATFORMS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
# Description

This PR builds a `dev` tagged image based on the `main` branch when a new PR is merged or daily at 4am to catch any dependency build errors.

## Changelog

### Added

- build a `dev` image and publish it to GHCR