### PR TITLE
[Bug] Don't return SAMEORIGIN twice (Hotfix Release v0.13.3)

### DIFF
--- a/app/Http/Middleware/FrameAllowOptions.php
+++ b/app/Http/Middleware/FrameAllowOptions.php
@@ -17,7 +17,9 @@ class FrameAllowOptions
     {
         $response = $next($request);
 
-        $response->header('X-Frame-Options', 'ALLOW-FROM '.config('speedtest.allow_embeds'));
+        if (! blank(config('speedtest.allow_embeds'))) {
+            $response->header('X-Frame-Options', 'ALLOW-FROM '.config('speedtest.allow_embeds'));
+        }
 
         return $response;
     }

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -6,9 +6,9 @@ return [
     /**
      * Build information
      */
-    'build_date' => Carbon::parse('2023-11-11'),
+    'build_date' => Carbon::parse('2023-11-12'),
 
-    'build_version' => '0.13.2',
+    'build_version' => '0.13.3',
 
     /**
      * General

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -27,5 +27,5 @@ return [
     /**
      * Security
      */
-    'allow_embeds' => env('ALLOW_EMBEDS', 'SAMEORIGIN'),
+    'allow_embeds' => env('ALLOW_EMBEDS', null),
 ];


### PR DESCRIPTION
# Description

This PR makes it so it won't modify the header if `ALLOW_EMBEDS` is empty.

- closes #903 

## Changelog

### Fixed

- `SAMEORIGIN` showing up twice
