### PR TITLE
[Feature] Made more result columns sortable

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -100,10 +100,12 @@ class ResultResource extends Resource
         return $table
             ->columns([
                 TextColumn::make('id')
-                    ->label('ID'),
+                    ->label('ID')
+                    ->sortable(),
                 TextColumn::make('server')
                     ->getStateUsing(fn (Result $record): ?string => ! blank($record->server_id) ? $record->server_id.' ('.$record->server_name.')' : null)
-                    ->toggleable(),
+                    ->toggleable()
+                    ->sortable(),
                 IconColumn::make('successful')
                     ->boolean()
                     ->toggleable(),
@@ -112,13 +114,16 @@ class ResultResource extends Resource
                     ->toggleable(),
                 TextColumn::make('download')
                     ->label('Download (Mbps)')
-                    ->getStateUsing(fn (Result $record): ?string => ! blank($record->download) ? toBits(convertSize($record->download), 2) : null),
+                    ->getStateUsing(fn (Result $record): ?string => ! blank($record->download) ? toBits(convertSize($record->download), 2) : null)
+                    ->sortable(),
                 TextColumn::make('upload')
                     ->label('Upload (Mbps)')
-                    ->getStateUsing(fn (Result $record): ?string => ! blank($record->upload) ? toBits(convertSize($record->upload), 2) : null),
+                    ->getStateUsing(fn (Result $record): ?string => ! blank($record->upload) ? toBits(convertSize($record->upload), 2) : null)
+                    ->sortable(),
                 TextColumn::make('ping')
                     ->label('Ping (Ms)')
-                    ->toggleable(),
+                    ->toggleable()
+                    ->sortable(),
                 TextColumn::make('download_jitter')
                     ->getStateUsing(fn (Result $record): ?string => json_decode($record->data, true)['download']['latency']['jitter'] ?? null)
                     ->toggleable()

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -127,15 +127,18 @@ class ResultResource extends Resource
                 TextColumn::make('download_jitter')
                     ->getStateUsing(fn (Result $record): ?string => json_decode($record->data, true)['download']['latency']['jitter'] ?? null)
                     ->toggleable()
-                    ->toggledHiddenByDefault(),
+                    ->toggledHiddenByDefault()
+                    ->sortable(),
                 TextColumn::make('upload_jitter')
                     ->getStateUsing(fn (Result $record): ?string => json_decode($record->data, true)['upload']['latency']['jitter'] ?? null)
                     ->toggleable()
-                    ->toggledHiddenByDefault(),
+                    ->toggledHiddenByDefault()
+                    ->sortable(),
                 TextColumn::make('ping_jitter')
                     ->getStateUsing(fn (Result $record): ?string => json_decode($record->data, true)['ping']['jitter'] ?? null)
                     ->toggleable()
-                    ->toggledHiddenByDefault(),
+                    ->toggledHiddenByDefault()
+                    ->sortable(),
                 TextColumn::make('created_at')
                     ->label('Created')
                     ->dateTime($settings->time_format ?? 'M j, Y G:i:s')


### PR DESCRIPTION
# Description

This PR makes `id`, `server`, `download`, `upload`, `ping` and `jitter` columns sortable in the Results table.

Closes #924 

## Changelog

### Changed

- made more Results table sortable
