### PR TITLE
[Bug] Refactor usage of time zones

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -49,7 +49,7 @@ class Kernel extends ConsoleKernel
                 // Evaluate if a run is needed based on the schedule
                 $cron = new CronExpression($settings->speedtest_schedule);
 
-                return $cron->isDue();
+                return $cron->isDue(now()->timezone($settings->timezone ?? 'UTC'));
             });
     }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,6 +39,7 @@ class Kernel extends ConsoleKernel
             );
         })
             ->everyMinute()
+            ->timezone($settings->timezone ?? 'UTC')
             ->when(function () use ($settings) {
                 // Don't run if the schedule is missing (aka disabled)
                 if (blank($settings->speedtest_schedule)) {

--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -52,8 +52,7 @@ class GeneralPage extends SettingsPage
                                     ->required()
                                     ->columnSpan(['md' => 2]),
                                 Forms\Components\Select::make('timezone')
-                                    ->label('Display time zone')
-                                    ->helperText(new HtmlString('Display time zone only changes the offset in views and <span class="underline">does not</span> effect the scheduler.'))
+                                    ->label('Time zone')
                                     ->options(Timezone::all()->pluck('code', 'code'))
                                     ->searchable()
                                     ->required(),

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -14,6 +14,7 @@ class HomeController extends Controller
     public function __invoke(Request $request)
     {
         $settings = new GeneralSettings();
+
         if (! $settings->public_dashboard_enabled) {
             return redirect()->route('filament.admin.auth.login');
         }


### PR DESCRIPTION
⚠️ WIP - this PR isn't ready for primetime just yet.

# Description

This PR looks to address the issues around usage of time zones throughout the application. #846 was a useful exercise in an overly complex solution.

## Guiding requirements

- [x] Records should be stored in the database as UTC.
- [x] Scheduled should be aware of the time zone setting.
- [x] Cron evaluation should be aware of the time zone setting.
- [x] Since last result should be aware of the time zone setting.
- [x] Default display timezone is in UTC.
- [x] Results table should have the datetime based on the time zone setting.
- [x] Graphs should have the correct datetime based on the time zone settings.
- [x] InfluxDB should still receive the UTC based timestamp.
- [x] Passing the host OS's time zone is no longer needed.
- [x] Passing a `TZ=` environment variable is no longer needed.

## To-dos

- [x] More testing to make this as simple as possible.
- [ ] Update docs to correctly set the time zone.

## Reference issues

- closes #194
- #242
- #631 
- closes #649 
- closes #659
- #696 
- #800  
- closes #805 
- closes #859 
- closes #916 

## Changelog

### Changed

- set scheduled tasks time zone
- set `$cron->isDue` to use the current local time to evaluate if a cron is due

### Fixed

- the jank and complexity surrounding dealing with time zones

### Removed

- no longer need to mount `'/etc/localtime:/etc/localtime:ro'` to pass the host machine's time
- no longer need to pass `TZ` as an environment variable

## Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/ddbb7b33-f6c0-4579-8af9-d1d5b156340b)
_Sanity checking time zones, datetimes and conversions to local time_
