### PR TITLE
[Bug] Use admin url so intended destination is used

### DIFF
--- a/resources/views/get-started.blade.php
+++ b/resources/views/get-started.blade.php
@@ -42,7 +42,7 @@
                                 </div>
 
                                 <h2 class="min-w-0 text-sm font-semibold leading-6 text-white">
-                                    <a href="{{ url('/admin/login') }}" class="flex gap-x-2">
+                                    <a href="{{ url('/admin') }}" class="flex gap-x-2">
                                         <span class="truncate">Sign In</span>
                                         <span class="text-amber-400">/</span>
                                         <span class="whitespace-nowrap">Admin Panel</span>


### PR DESCRIPTION
# Description

This PR changes the anchor's URL so that the intended destination is used when signing in for the first time.

- closes #930 

## Changelog

### Fixed

- first time auth loop