### PR TITLE
[Bug] Removed should be unique trait from exec speedtest job

### DIFF
--- a/app/Jobs/ExecSpeedtest.php
+++ b/app/Jobs/ExecSpeedtest.php
@@ -4,7 +4,6 @@ namespace App\Jobs;
 
 use App\Models\Result;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -13,7 +12,7 @@ use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class ExecSpeedtest implements ShouldBeUnique, ShouldQueue
+class ExecSpeedtest implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 


### PR DESCRIPTION
# Description

Removed `ShouldBeUnique` trait from `ExecSpeedtest` job as it can cause instability in some cases when a cache lock can't be obtained.

## Changelog

### Removed

- `ShouldBeUnique` trait from `ExecSpeedtest` job
