### PR TITLE
[Bug] Fixed incorrect path for the home constant

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -17,7 +17,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/';
 
     /**
      * Define your route model bindings, pattern filters, and other route configuration.


### PR DESCRIPTION
# Description

This PR fixes the `home` constant path which can cause redirect issues as `/home` was not a valid path.

## Changelog

### Changed

- `home` path