### PR TITLE
[Bug] After login redirect to the admin panel instead of the root url

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -14,6 +14,8 @@ use Filament\Pages\Dashboard as BasePage;
 
 class Dashboard extends BasePage
 {
+    public bool $publicDashboard = false;
+
     protected static ?string $pollingInterval = null;
 
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
@@ -22,11 +24,24 @@ class Dashboard extends BasePage
 
     protected static string $view = 'filament.pages.dashboard';
 
+    public function mount()
+    {
+        $settings = new GeneralSettings();
+
+        $this->publicDashboard = $settings->public_dashboard_enabled;
+    }
+
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('home')
+                ->label('Public Dashboard')
+                ->color('gray')
+                ->hidden(! $this->publicDashboard)
+                ->url('/'),
             Action::make('speedtest')
                 ->label('Queue Speedtest')
+                ->color('primary')
                 ->action('queueSpeedtest')
                 ->hidden(fn (): bool => ! auth()->user()->is_admin && ! auth()->user()->is_user),
         ];

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -80,10 +80,6 @@ class AdminPanelProvider extends PanelProvider
                     ->collapsible(false),
             ])
             ->navigationItems([
-                NavigationItem::make('Home')
-                    ->url('/')
-                    ->icon('heroicon-o-home')
-                    ->sort(0),
                 NavigationItem::make('Documentation')
                     ->url('https://docs.speedtest-tracker.dev/', shouldOpenInNewTab: true)
                     ->icon('heroicon-o-book-open')

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\HomeController;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -18,9 +19,8 @@ Route::get('/', HomeController::class)
     ->middleware('x-frame-allow')
     ->name('home');
 
-Route::get('/login', function () {
-    return redirect('/admin/login');
-})->name('login');
+Route::redirect('/login', '/admin/login')
+    ->name('login');
 
 require __DIR__.'/debug.php';
 


### PR DESCRIPTION
# Description

This PR makes a change to prevent being redirected to the root url after login. By default Filament uses the first navigation item as the URL to redirect to. This was set to the public facing dashboard which caused an undesirable auth path.

- closes #967 

## Changelog

### Added

- "Public Dashboard" link to the Dashboard page header.

### Fixed

- "Public Dashboard" link now is hidden when disabled

### Removed

- "Home" link from the sidebar navigation