### PR TITLE
[Feature] Database has time zone setting

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -50,9 +50,21 @@ class GeneralPage extends SettingsPage
                                 Forms\Components\TextInput::make('site_name')
                                     ->maxLength(50)
                                     ->required()
-                                    ->columnSpan(['md' => 2]),
+                                    ->columnSpanFull(),
+                                Forms\Components\Toggle::make('public_dashboard_enabled')
+                                    ->label('Public dashboard'),
+                            ])
+                            ->compact()
+                            ->columns([
+                                'default' => 1,
+                                'md' => 2,
+                            ]),
+
+                        Forms\Components\Section::make('Time Zone Settings')
+                            ->schema([
                                 Forms\Components\Select::make('timezone')
                                     ->label('Time zone')
+                                    ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/" target="_blank" rel="nofollow">Docs</a>'))
                                     ->options(TimeZoneHelper::list())
                                     ->searchable()
                                     ->required(),
@@ -61,6 +73,9 @@ class GeneralPage extends SettingsPage
                                     ->placeholder('M j, Y G:i:s')
                                     ->maxLength(25)
                                     ->required(),
+                                Forms\Components\Toggle::make('db_has_timezone')
+                                    ->label('Database has time zone')
+                                    ->helperText(new HtmlString('Enable if your database <strong>has</strong> a time zone already set.')),
                             ])
                             ->compact()
                             ->columns([
@@ -107,18 +122,6 @@ class GeneralPage extends SettingsPage
                                     ->getSearchResultsUsing(fn (string $search): array => $this->getServerSearchOptions($search))
                                     ->getOptionLabelsUsing(fn (array $values): array => $this->getServerLabels($values))
                                     ->columnSpan('full'),
-                            ])
-                            ->compact()
-                            ->columns([
-                                'default' => 1,
-                                'md' => 2,
-                            ]),
-
-                        Forms\Components\Section::make('Public Dashboard Settings')
-                            ->schema([
-                                Forms\Components\Toggle::make('public_dashboard_enabled')
-                                    ->label('Enable')
-                                    ->columnSpan(2),
                             ])
                             ->compact()
                             ->columns([

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Exports\ResultsSelectedBulkExport;
 use App\Filament\Resources\ResultResource\Pages;
+use App\Helpers\TimeZoneHelper;
 use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Carbon\Carbon;
@@ -142,7 +143,7 @@ class ResultResource extends Resource
                 TextColumn::make('created_at')
                     ->label('Created')
                     ->dateTime($settings->time_format ?? 'M j, Y G:i:s')
-                    ->timezone($settings->timezone ?? 'UTC')
+                    ->timezone(TimeZoneHelper::displayTimeZone($settings))
                     ->sortable(),
             ])
             ->filters([

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Helpers\TimeZoneHelper;
 use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
@@ -77,7 +78,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone($settings->timezone)->format('M d - G:i')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(TimeZoneHelper::displayTimeZone($settings))->format('M d - G:i')),
         ];
     }
 

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Helpers\TimeZoneHelper;
 use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
@@ -59,7 +60,7 @@ class RecentPingChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone($settings->timezone)->format('M d - G:i')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(TimeZoneHelper::displayTimeZone($settings))->format('M d - G:i')),
         ];
     }
 

--- a/app/Filament/Widgets/RecentSpeedChartWidget.php
+++ b/app/Filament/Widgets/RecentSpeedChartWidget.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Widgets;
 
+use App\Helpers\TimeZoneHelper;
 use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
@@ -68,7 +69,7 @@ class RecentSpeedChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone($settings->timezone)->format('M d - G:i')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(TimeZoneHelper::displayTimeZone($settings))->format('M d - G:i')),
         ];
     }
 

--- a/app/Helpers/TimeZoneHelper.php
+++ b/app/Helpers/TimeZoneHelper.php
@@ -2,12 +2,27 @@
 
 namespace App\Helpers;
 
+use App\Settings\GeneralSettings;
 use DateTimeZone;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Str;
 
 class TimeZoneHelper
 {
+    /**
+     * Returns the display timezone
+     */
+    public static function displayTimeZone(GeneralSettings $settings): string
+    {
+        // Don't translate to local time if the database already returns it.
+        if ($settings->db_has_timezone) {
+            return 'UTC';
+        }
+
+        return $settings->timezone
+            ?? 'UTC';
+    }
+
     /**
      * Returns a collection of time zones with their offset from UTC.
      */

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -28,7 +28,19 @@ class HomeController extends Controller
             return view('get-started');
         }
 
+        /**
+         * This jank needs to happen because some people like
+         * to watch the world burn by setting a time zone
+         * in their database instances.
+         */
+        if ($settings->db_has_timezone) {
+            date_default_timezone_set($settings->timezone ?? 'UTC');
+        }
+
+        $diff = $latestResult->created_at->diffForHumans();
+
         return view('dashboard', [
+            'diff' => $diff,
             'latestResult' => $latestResult,
         ]);
     }

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -19,6 +19,8 @@ class GeneralSettings extends Settings
 
     public string $timezone;
 
+    public bool $db_has_timezone;
+
     public bool $public_dashboard_enabled;
 
     public static function group(): string

--- a/database/settings/2023_12_12_234839_add_db_has_time_zone_to_general_settings.php
+++ b/database/settings/2023_12_12_234839_add_db_has_time_zone_to_general_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.db_has_timezone', false);
+    }
+};

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -4,11 +4,11 @@
             @livewire(\App\Filament\Widgets\StatsOverviewWidget::class)
         </div>
 
-        @if ($latestResult)
+        @isset($latestResult)
             <div class="text-sm font-semibold leading-6 text-center col-span-full sm:text-base">
-                Latest result: {{ $latestResult?->created_at->diffForHumans() }}
+                Latest result: <time datetime="{{ $latestResult->created_at }}">{{ $diff }}</time>
             </div>
-        @endif
+        @endisset
 
         <div class="col-span-full">
             @livewire(\App\Filament\Widgets\RecentSpeedChartWidget::class)

--- a/resources/views/livewire/debug/timezone.blade.php
+++ b/resources/views/livewire/debug/timezone.blade.php
@@ -62,7 +62,7 @@
                 <ul role="list" class="divide-y divide-gray-200">
                     <li class="px-4 py-4 sm:px-6">
                         <p class="text-sm font-medium text-gray-900">Latest result ran at</p>
-                        <p class="text-sm text-gray-500 truncate">{{ $latest->created_at->timezone($settings['timezone'] ?? 'UTC')->format('M. jS, Y h:i:s') }}</p>
+                        <p class="text-sm text-gray-500 truncate">{{ $latest->created_at->timezone($settings['db_has_timezone'] ? null : $settings['timezone'] ?? 'UTC')->format('M. jS, Y h:i:s') }}</p>
                     </li>
 
                     <li class="px-4 py-4 sm:px-6">


### PR DESCRIPTION
# Description

This PR introduces a `db_has_timezone` setting that let's the application know the database is already reporting in the local time.

## Testing 

### Configuration

- `TZ` environment variable was not passed to the application's container.
- Database had a `TZ` environment variable of `America/New_York` which matched the setting in the application's UI.
- Local time was set in the `Time zone` setting under the "General Settings" page.
- `Database has time zone` was enabled.

### Results

- [x] The scheduler still runs at the correct time, (i.e. 7:25 PM EST).
- [x] The database returns `2023-12-12 19:25:xx` for the 7:25 PM scheduled run.
- [x] "Lastest result: ..." correctly displays the time difference
- [x] Results table correctly displays `2023-12-12 19:25:xx`
- [x] Charts correctly display `2023-12-12 19:25:xx`


## Changelog

### Added

- `db_has_timezone` to general settings

### Changed

- changed the layout of the general settings page

## Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/f9111c35-9824-448a-ad62-6eeee01a3c16)
_Dashboard_

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/74040f23-4d97-4344-8b4e-a69f798c5e17)
_Results Screenshot_

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/fe4406c7-3c83-46e7-961b-d112eee057db)
_General Settings page_
