### PR TITLE
[MAIL] Send mail with smtp without verifying SSL certificate

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -44,6 +44,7 @@ return [
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
             'local_domain' => env('MAIL_EHLO_DOMAIN'),
+            'verify_peer' => env('MAIL_VERIFY_SSL', 'true'),
         ],
 
         'ses' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -44,7 +44,7 @@ return [
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
             'local_domain' => env('MAIL_EHLO_DOMAIN'),
-            'verify_peer' => env('MAIL_VERIFY_SSL', 'true'),
+            'verify_peer' => env('MAIL_VERIFY_SSL', true),
         ],
 
         'ses' => [


### PR DESCRIPTION
config/mail.php: Added option to skip SSL certificate verification for self signed certificates

# Description
Using the current build the option to send mail with a self hosted SMTP server using a self signed SSL certificate is not possible. Adding the option to disable the verification process with the environmental variable `MAIL_VERIFY_SSL` allows to send mail.

Allowed values for  `MAIL_VERIFY_SSL` are `true` or `false`. Default is `true`

## Changelog

### Added
- config/mail.php
 ` 'verify_peer' => env('MAIL_VERIFY_SSL', 'true'),`