### PR TITLE
[Bug] Workflow updates

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,10 @@
 name: Lint
+
 on:
-  - push
+  push:
+  pull_request:
+  workflow_dispatch:
+
 jobs:
   duster:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         operating-system:
           - ubuntu-latest
         php-version:
-          - '8.1'
+          - '8.2'
     name: php ${{ matrix.php-version }} on ${{ matrix.operating-system }}
     services:
       mysql:


### PR DESCRIPTION
# Description

Linting workflow isn't running when a PR is opened from a forked repo.

## Changelog

### Changed

- bumped `test.yml` workflow to use `php8.2`

### Fixed

- run `lint.yml` on `pull_request` and `workflow_dispatch`
