### PR TITLE
[Bug] Disable nginx x-frame-options header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Copy package configs
-COPY --chmod=755 docker/deploy/etc/s6-overlay/ /etc/s6-overlay/
+COPY --chmod=755 docker/deploy/etc /etc
 
 # Copy app
 COPY --chown=webuser:webgroup . $WEBUSER_HOME

--- a/docker/deploy/etc/nginx/server-opts.d/security.conf
+++ b/docker/deploy/etc/nginx/server-opts.d/security.conf
@@ -1,0 +1,25 @@
+#
+# Security Headers
+#
+
+# Prevent IFRAME spoofing attacks
+# Disabled for Speedtest Tracked to be embedded.
+# add_header X-Frame-Options           "SAMEORIGIN" always;
+
+# Prevent MIME attacks
+add_header X-Content-Type-Options    "nosniff" always;
+
+# Prevent Referrer URL from being leaked
+add_header Referrer-Policy           "no-referrer-when-downgrade" always;
+
+# Configure Content Security Policy
+# UPDATE - September 2020: Commenting this out until we grasp better security requirements
+#add_header Content-Security-Policy   "default-src 'self' http: https: data: blob: 'unsafe-inline'" always;
+
+# Enable HSTS
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+
+# Prevent access to . files (excent the well-known directory)
+location ~ /\.(?!well-known) {
+    deny all;
+}


### PR DESCRIPTION
# Description

This PR disabled nginx's x-frame-options header in an attempt to prevent multiple headers.

## Changelog

### Changed

- disabled `add_header` in `security.conf`
