### PR TITLE
Lock PHP image into "serversideup/php" v2.2.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM serversideup/php:8.2-fpm-nginx
+FROM serversideup/php:8.2-fpm-nginx-v2.2.1
 
 # Add /config to allowed directory tree
 ENV PHP_OPEN_BASEDIR=$WEBUSER_HOME:/config/:/dev/stdout:/tmp


### PR DESCRIPTION


# Description
We have a massive release coming up soon for **[serversideup/php](https://serversideup.net/open-source/docker-php/).** We don't want to create any unnecessary downstream issues 🤠

As of today, changing from "8.2-fpm-nginx" to "8.2-fpm-nginx-v2.2.1" should not have any effect.

Once the beta gets merged, that will be a different story. 😅

More about the beta here:
https://github.com/serversideup/docker-php/discussions/254

## Changelog

### Changed

- Change base image from `serversideup/php:8.2-fpm-nginx` to `serversideup/php:8.2-fpm-nginx-v2.2.1`
