### PR TITLE
[Feature] Check for a new version and notify the admin(s)

### DIFF
--- a/app/Console/Commands/VersionChecker.php
+++ b/app/Console/Commands/VersionChecker.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use App\Services\SystemChecker;
+use Filament\Notifications\Actions\Action;
+use Filament\Notifications\Notification;
+use Illuminate\Console\Command;
+
+class VersionChecker extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'app:version';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Sends a notification to the admin users when Speedtest Tracker is outdated.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $system = new SystemChecker;
+
+        if (! $system->isOutOfDate()) {
+            return Command::SUCCESS;
+        }
+
+        $admins = User::select(['id', 'name', 'email', 'role'])
+            ->where('role', 'admin')
+            ->get();
+
+        foreach ($admins as $user) {
+            Notification::make()
+                ->title('Update Available')
+                ->body("There's a new version of Speedtest Tracker available: {$system->getRemoteVersion()}")
+                ->info()
+                ->actions([
+                    Action::make('view releases')
+                        ->button()
+                        ->color('gray')
+                        ->url('https://github.com/alexjustesen/speedtest-tracker/releases')
+                        ->openUrlInNewTab(),
+                ])
+                ->sendToDatabase($user);
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -2,6 +2,7 @@
 
 namespace App\Console;
 
+use App\Console\Commands\VersionChecker;
 use App\Jobs\ExecSpeedtest;
 use App\Settings\GeneralSettings;
 use Cron\CronExpression;
@@ -16,6 +17,13 @@ class Kernel extends ConsoleKernel
     protected function schedule(Schedule $schedule): void
     {
         $settings = new GeneralSettings();
+
+        /**
+         * Checked for new versions weekly on Thursday because
+         * I usually do releases on Thursday or Friday.
+         */
+        $schedule->command(VersionChecker::class)->weeklyOn(5)
+            ->timezone($settings->timezone ?? 'UTC');
 
         /**
          * Check for speedtests that need to run.

--- a/app/Filament/VersionProviders/SpeedtestTrackerVersionProvider.php
+++ b/app/Filament/VersionProviders/SpeedtestTrackerVersionProvider.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Services\SystemChecker;
 use Awcodes\FilamentVersions\Providers\Contracts\VersionProvider;
 
 class SpeedtestTrackerVersionProvider implements VersionProvider
@@ -12,7 +13,7 @@ class SpeedtestTrackerVersionProvider implements VersionProvider
     public function getVersion(): string
     {
         return app()->isProduction()
-            ? config('speedtest.build_version')
+            ? app(new SystemChecker)->getLocalVersion()
             : config('app.env');
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Services\SystemChecker;
+use Illuminate\Foundation\Console\AboutCommand;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 
@@ -28,5 +30,12 @@ class AppServiceProvider extends ServiceProvider
         if (config('app.force_https')) {
             URL::forceScheme('https');
         }
+
+        $system = new SystemChecker;
+
+        AboutCommand::add('Speedtest Tracker', fn () => [
+            'Version' => $system->getLocalVersion(),
+            'Out of date' => $system->isOutOfDate() ? 'Yes' : 'No',
+        ]);
     }
 }

--- a/app/Services/SystemChecker.php
+++ b/app/Services/SystemChecker.php
@@ -2,8 +2,6 @@
 
 namespace App\Services;
 
-use Illuminate\Support\Facades\Cache;
-
 /**
  * 🤔 inspired by: https://github.com/ploi/roadmap/blob/main/app/Services/SystemChecker.php
  */
@@ -50,9 +48,9 @@ class SystemChecker
     public function flushVersionData()
     {
         try {
-            Cache::forget($this->cacheKeyLocal);
+            cache()->forget($this->cacheKeyLocal);
 
-            Cache::forget($this->cacheKeyRemote);
+            cache()->forget($this->cacheKeyRemote);
         } catch (\Exception $exception) {
             // fail silently, it's ok
         }

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -4,13 +4,6 @@ use Carbon\Carbon;
 
 return [
     /**
-     * Build information
-     */
-    'build_date' => Carbon::parse('2023-12-20'),
-
-    'build_version' => '0.14.1',
-
-    /**
      * General
      */
     'content_width' => env('CONTENT_WIDTH', '7xl'),


### PR DESCRIPTION
# Description

This PR implements the system version checker and provides notifications to the admin user(s) when a new version of Speedtest Tracker is available.

_Heavily_ inspired by how [Ploi Roadmap](https://github.com/ploi/roadmap) handles version checking.

- closes #977 

## Changelog

### Added

- `artisan about` now reports the local version and if the local version is out of date.
- check for updates weekly and notify the admin user(s) if one is available via database notification

### Changed

- use `SystemChecker` instead of `config/speedtest.php` to get the current version.

## Screenshots

### Update Available
![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/02d31974-300d-416c-8706-4aa315fb39be)

### About Command
![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/7f17234e-be20-4fec-ae00-36c01cf86fa0)
