### PR TITLE
[Hotfix] v0.14.2-beta2

### DIFF
--- a/app/Services/SystemChecker.php
+++ b/app/Services/SystemChecker.php
@@ -26,9 +26,7 @@ class SystemChecker
 
     public function getLocalVersion()
     {
-        return cache()->remember($this->cacheKeyLocal, now()->addDay(), function () {
-            return shell_exec('git describe --tag --abbrev=0');
-        });
+        return config('speedtest.build_version');
     }
 
     public function getRemoteVersion()
@@ -42,7 +40,7 @@ class SystemChecker
     {
         $this->getVersions();
 
-        return $this->localVersion < $this->remoteVersion || $this->localVersion != $this->remoteVersion;
+        return 'v'.$this->localVersion != $this->remoteVersion;
     }
 
     public function flushVersionData()

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -4,6 +4,13 @@ use Carbon\Carbon;
 
 return [
     /**
+     * Build information
+     */
+    'build_date' => Carbon::parse('2023-12-23'),
+
+    'build_version' => '0.14.2-beta2',
+
+    /**
      * General
      */
     'content_width' => env('CONTENT_WIDTH', '7xl'),


### PR DESCRIPTION
# Description

Since `git` is not included in the production image and it increases the size of the image by `~90 MB` this reverts checking the local version to the config file instead.

- closes #1011 

## Changelog

### Fixed

- use config to check local version
