### PR TITLE
[Bug] added livewire paths to exception list

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -13,5 +13,6 @@ class VerifyCsrfToken extends Middleware
      */
     protected $except = [
         '/',
+        'livewire/*',
     ];
 }


### PR DESCRIPTION
# Description

The PR attempts to fix the invalid token error that is present on the public dashboard when embedding it within an iframe.

## Changelog

### Added

- `livewire/*` to verify csrf exception list
