### PR TITLE
[Feature] Extend number helper

### DIFF
--- a/app/Helpers/Number.php
+++ b/app/Helpers/Number.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Helpers;
+
+use Illuminate\Support\Number as SupportNumber;
+
+class Number extends SupportNumber
+{
+    /**
+     * Convert the given number to its file size equivalent in bits.
+     */
+    public static function fileSizeBits(int|float $bits, int $precision = 0, ?int $maxPrecision = null, bool $perSecond = false): string
+    {
+        $units = match ($perSecond) {
+            true => ['Bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps', 'Ebps', 'Zbps', 'Ybps'],
+            default => ['B', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb']
+        };
+
+        for ($i = 0; ($bits / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bits /= 1024;
+        }
+
+        return sprintf('%s %s', static::format($bits, $precision, $maxPrecision), $units[$i]);
+    }
+
+    /**
+     * Compare the dividend and divisor to get the percent change.
+     */
+    public static function percentChange(float $dividend, float $divisor, int $precision = 0): string
+    {
+        $quotient = ($dividend - $divisor) / $divisor;
+
+        // TODO: determine if I want to return the full percentage (with %) or without.
+        // return SupportNumber::percentage(($quotient * 100), precision: $precision);
+        return number_format(round($quotient, $precision), $precision);
+    }
+}

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Events\ResultCreated;
+use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
@@ -105,5 +106,29 @@ class Result extends Model
             'upload' => $data['upload']['latency']['jitter'] ?? null,
             'ping' => $data['ping']['jitter'] ?? null,
         ];
+    }
+
+    /**
+     * Get the result's download in bits.
+     */
+    protected function downloadBits(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value): ?string => ! blank($this->download) && is_numeric($this->download)
+                ? number_format(num: $this->download * 8, decimals: 0, thousands_separator: '')
+                : null,
+        );
+    }
+
+    /**
+     * Get the result's upload in bits.
+     */
+    protected function uploadBits(): Attribute
+    {
+        return Attribute::make(
+            get: fn (mixed $value): ?string => ! blank($this->upload) && is_numeric($this->upload)
+                ? number_format(num: $this->upload * 8, decimals: 0, thousands_separator: '')
+                : null,
+        );
     }
 }


### PR DESCRIPTION
# Description

The PR extends Laravel's new number helper with some data bit helpers.

## Changelog

### Added

- `downloadBits` and `uploadBits` attributes to Results model
- `Number` helper with data transfer helper