### PR TITLE
[Bug] Removed initial cache clear on startup

### DIFF
--- a/docker/deploy/etc/s6-overlay/scripts/laravel-automations
+++ b/docker/deploy/etc/s6-overlay/scripts/laravel-automations
@@ -16,12 +16,6 @@ chown -R webuser:webgroup $WEBUSER_HOME/storage
 echo "✅  Permissions fixed."
 echo ""
 
-# Build cache
-echo "🧹  Clearing any previous caches..."
-s6-setuidgid webuser php $WEBUSER_HOME/artisan optimize:clear --no-ansi -q
-echo "✅  Cache cleared."
-echo ""
-
 if [ ${DB_CONNECTION:="sqlite"} = "sqlite" ]; then
     # create symlinks
     echo "🔗  Creating database symlink..."
@@ -89,7 +83,7 @@ fi
 
 echo ""
 
-# Build cache
+# Refresh cache
 echo "💰  Building the cache..."
 s6-setuidgid webuser php $WEBUSER_HOME/artisan view:clear --no-ansi -q
 s6-setuidgid webuser php $WEBUSER_HOME/artisan optimize --no-ansi -q


### PR DESCRIPTION
# Description

This PR removes initial `cache:clear` on startup which can cause issues on new installs when the database isn't ready yet.

- closes #1078 
- closes #1088 
- closes #1090 
- closes #1092 

## Changelog

### Removed

- `cache:clear` on startup
