### PR TITLE
[Bug] Wrap system maintenance commands in try to soft fail the command

### DIFF
--- a/app/Console/Commands/SystemMaintenance.php
+++ b/app/Console/Commands/SystemMaintenance.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 
 class SystemMaintenance extends Command
 {
@@ -36,8 +37,20 @@ class SystemMaintenance extends Command
      */
     protected function refreshCache(): void
     {
-        Artisan::call('optimize:clear');
+        try {
+            Artisan::call('optimize:clear');
+        } catch (\Throwable $th) {
+            Log::info('System maintenance failed to clear the cache.');
 
-        Artisan::call('optimize');
+            return;
+        }
+
+        try {
+            Artisan::call('optimize');
+        } catch (\Throwable $th) {
+            Log::info('System maintenance failed to fresh the cache.');
+
+            return;
+        }
     }
 }


### PR DESCRIPTION
# Description

This PR wraps `app:system-maintenance` commands in `try` blocks so it soft fails.

## Changelog

### Changed

- wrapped system maintenance commands in try block
