### PR TITLE
Release v0.15.2 (Hotfix)

### DIFF
--- a/app/Console/Commands/SystemMaintenance.php
+++ b/app/Console/Commands/SystemMaintenance.php
@@ -27,30 +27,22 @@ class SystemMaintenance extends Command
      */
     public function handle()
     {
-        $this->refreshCache();
-
-        return Command::SUCCESS;
-    }
-
-    /**
-     * Clear and refresh the cache.
-     */
-    protected function refreshCache(): void
-    {
         try {
-            Artisan::call('optimize:clear');
+            Artisan::call('cache:clear');
         } catch (\Throwable $th) {
             Log::info('System maintenance failed to clear the cache.');
 
-            return;
+            return Command::FAILURE;
         }
 
         try {
-            Artisan::call('optimize');
+            Artisan::call('view:clear');
         } catch (\Throwable $th) {
-            Log::info('System maintenance failed to fresh the cache.');
+            Log::info('System maintenance failed to clear the view cache.');
 
-            return;
+            return Command::FAILURE;
         }
+
+        return Command::SUCCESS;
     }
 }

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -8,7 +8,7 @@ return [
      */
     'build_date' => Carbon::parse('2024-02-07'),
 
-    'build_version' => 'v0.15.1',
+    'build_version' => 'v0.15.2',
 
     /**
      * General


### PR DESCRIPTION
# Description

This PR changes `SystemMaintenance` command to only clear the `cache` and `view` caches. In #1065 it was identified that clearing the config can stop the container from running correctly.

## Changelog

### Changed

- `SystemMaintenance` command to only clear the cache and view cache
