### PR TITLE
[Feature] Automatically prune results

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -5,6 +5,7 @@ namespace App\Console;
 use App\Console\Commands\RunOoklaSpeedtest;
 use App\Console\Commands\SystemMaintenance;
 use App\Console\Commands\VersionChecker;
+use App\Models\Result;
 use App\Settings\GeneralSettings;
 use Cron\CronExpression;
 use Illuminate\Console\Scheduling\Schedule;
@@ -20,9 +21,13 @@ class Kernel extends ConsoleKernel
         $settings = new GeneralSettings();
 
         /**
-         * Trigger pruning of models.
+         * Checks if Result model records should be pruned.
          */
-        $schedule->command('model:prune')->daily();
+        if ($settings->prune_results_older_than > 0) {
+            $schedule->command('model:prune', [
+                '--model' => [Result::class],
+            ])->daily();
+        }
 
         /**
          * Perform system maintenance weekly on Sunday morning,

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -20,6 +20,11 @@ class Kernel extends ConsoleKernel
         $settings = new GeneralSettings();
 
         /**
+         * Trigger pruning of models.
+         */
+        $schedule->command('model:prune')->daily();
+
+        /**
          * Perform system maintenance weekly on Sunday morning,
          * start off the week nice and fresh.
          */

--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -92,6 +92,14 @@ class GeneralPage extends SettingsPage
                                     ->hint(new HtmlString('&#x1f517;<a href="https://crontab.cronhub.io/" target="_blank" rel="nofollow">Cron Generator</a>'))
                                     ->nullable()
                                     ->columnSpan(1),
+                                Forms\Components\TextInput::make('prune_results_older_than')
+                                    ->helperText('Set to zero to disable pruning.')
+                                    ->suffix('days')
+                                    ->numeric()
+                                    ->required()
+                                    ->minValue(0)
+                                    ->maxValue(9999)
+                                    ->columnSpan(1),
                                 Forms\Components\Select::make('speedtest_server')
                                     ->label('Speedtest servers')
                                     ->helperText('Leave empty to let the system pick the best server.')
@@ -102,7 +110,7 @@ class GeneralPage extends SettingsPage
                                     ->options(GetOoklaSpeedtestServers::run())
                                     ->getSearchResultsUsing(fn (string $search): array => $this->getServerSearchOptions($search))
                                     ->getOptionLabelsUsing(fn (array $values): array => $this->getServerLabels($values))
-                                    ->columnSpan('full'),
+                                    ->columnSpanFull(),
                             ])
                             ->compact()
                             ->columns([

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -86,10 +86,6 @@ class Result extends Model
     {
         $settings = new GeneralSettings();
 
-        if ($settings->prune_results_older_than === 0) {
-            return static::query();
-        }
-
         return static::where('created_at', '<=', now()->subDays($settings->prune_results_older_than));
     }
 

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -8,6 +8,8 @@ class GeneralSettings extends Settings
 {
     public bool $auth_enabled;
 
+    public int $prune_results_older_than;
+
     public ?string $speedtest_schedule;
 
     /** @var string[] */

--- a/database/settings/2024_02_19_022251_add_prune_results_to_general_settings.php
+++ b/database/settings/2024_02_19_022251_add_prune_results_to_general_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.prune_results_older_than', 0);
+    }
+};


### PR DESCRIPTION
## 📃 Description

This PR introduces a new setting to set the number of days until a `Result` model record is pruned from the database. Default is disabled.

- closes #880 

## 🪵 Changelog

### ➕ Added

- prune `Result` model records automatically
