### PR TITLE
[Bug] Correctly format failed speedtests

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -78,7 +78,7 @@ class ResultResource extends Resource
                                 ->label('Error Message')
                                 ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/help/error-messages" target="_blank" rel="nofollow">Error Messages</a>'))
                                 ->hidden(fn (Result $record): bool => $record->status !== ResultStatus::Failed)
-                                ->columnSpanFull()
+                                ->columnSpanFull(),
                         ])
                         ->columnSpan(2),
                     Forms\Components\Section::make()

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -74,6 +74,11 @@ class ResultResource extends Resource
                                 ->label('Upload Jitter (Ms)'),
                             Forms\Components\TextInput::make('data.ping.jitter')
                                 ->label('Ping Jitter (Ms)'),
+                            Forms\Components\Textarea::make('data.message')
+                                ->label('Error Message')
+                                ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/help/error-messages" target="_blank" rel="nofollow">Error Messages</a>'))
+                                ->hidden(fn (Result $record): bool => $record->status !== ResultStatus::Failed)
+                                ->columnSpanFull()
                         ])
                         ->columnSpan(2),
                     Forms\Components\Section::make()
@@ -81,13 +86,13 @@ class ResultResource extends Resource
                             Forms\Components\Placeholder::make('service')
                                 ->content(fn (Result $result): string => $result->service),
                             Forms\Components\Placeholder::make('server_name')
-                                ->content(fn (Result $result): string => $result->server_name),
+                                ->content(fn (Result $result): ?string => $result->server_name),
                             Forms\Components\Placeholder::make('server_id')
                                 ->label('Server ID')
-                                ->content(fn (Result $result): string => $result->server_id),
+                                ->content(fn (Result $result): ?string => $result->server_id),
                             Forms\Components\Placeholder::make('server_host')
                                 ->label('Server ID')
-                                ->content(fn (Result $result): string => $result->server_id),
+                                ->content(fn (Result $result): ?string => $result->server_id),
                             Forms\Components\Checkbox::make('scheduled'),
                         ])
                         ->columns(1)
@@ -176,6 +181,7 @@ class ResultResource extends Resource
                     ->options(function (): array {
                         return Result::query()
                             ->select('data->interface->externalIp AS public_ip_address')
+                            ->where('status', '=', ResultStatus::Completed)
                             ->distinct()
                             ->get()
                             ->mapWithKeys(function (Result $item, int $key) {

--- a/app/Jobs/ExecSpeedtest.php
+++ b/app/Jobs/ExecSpeedtest.php
@@ -52,7 +52,8 @@ class ExecSpeedtest implements ShouldQueue
             $message = collect(array_filter($messages, 'json_validate'))->last();
 
             Result::create([
-                'data' => $message,
+                'service' => 'ookla',
+                'data' => json_decode($message, true),
                 'status' => ResultStatus::Failed,
                 'scheduled' => $this->scheduled,
             ]);

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -112,6 +112,16 @@ class Result extends Model
     }
 
     /**
+     * Get the result's download jitter in milliseconds.
+     */
+    protected function errorMessage(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => Arr::get($this->data, 'message', ''),
+        );
+    }
+
+    /**
      * Get the result's external ip address (yours).
      */
     protected function ipAddress(): Attribute


### PR DESCRIPTION
## 📃 Description

This PR correctly formats failed speedtests and adds the error message when viewing the result.

## 🪵 Changelog

### ➕ Added

- error message when viewing a result of a failed speedtest
- docs page for [error messages](https://docs.speedtest-tracker.dev/help/error-messages)

### 🔧 Fixed

- json data format for failed speedtests

## 📷 Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/c782fad7-c572-4dc3-a2ee-e3af4e28dc3b)
