### PR TITLE
[Bug] Capture 1 or true for successful status

### DIFF
--- a/app/Actions/MigrateBadJsonResults.php
+++ b/app/Actions/MigrateBadJsonResults.php
@@ -70,6 +70,7 @@ class MigrateBadJsonResults
                         'data' => json_decode($result->data),
                         'status' => match ($result->successful) {
                             1 => ResultStatus::Completed,
+                            true => ResultStatus::Completed,
                             default => ResultStatus::Failed,
                         },
                         'scheduled' => $result->scheduled,


### PR DESCRIPTION
## 📃 Description

This PR adds an additional check to the match statement to capture `1` and `true` for successful speedtests during data migration.

- closes #1177 
- mentioned in #1175 

## 🪵 Changelog

### ✏️ Changed

- data migration match statement.
