### PR TITLE
[Bug] Fixed incorrect file size bits calculation

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -57,14 +57,14 @@ class ResultResource extends Resource
                                 })
                                 ->columnSpan(2),
                             Forms\Components\TextInput::make('download')
-                                ->label('Download (Mbps)')
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    $component->state(! blank($state) ? toBits(convertSize($state), 4) : '');
+                                ->label('Download')
+                                ->afterStateHydrated(function (TextInput $component, Result $record) {
+                                    $component->state(! blank($record->download) ? Number::fileSizeBits(bits: $record->download_bits, precision: 2, perSecond: true) : '');
                                 }),
                             Forms\Components\TextInput::make('upload')
-                                ->label('Upload (Mbps)')
-                                ->afterStateHydrated(function (TextInput $component, $state) {
-                                    $component->state(! blank($state) ? toBits(convertSize($state), 4) : '');
+                                ->label('Upload')
+                                ->afterStateHydrated(function (TextInput $component, Result $record) {
+                                    $component->state(! blank($record->upload) ? Number::fileSizeBits(bits: $record->upload_bits, precision: 2, perSecond: true): '');
                                 }),
                             Forms\Components\TextInput::make('ping')
                                 ->label('Ping (Ms)'),

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -64,7 +64,7 @@ class ResultResource extends Resource
                             Forms\Components\TextInput::make('upload')
                                 ->label('Upload')
                                 ->afterStateHydrated(function (TextInput $component, Result $record) {
-                                    $component->state(! blank($record->upload) ? Number::fileSizeBits(bits: $record->upload_bits, precision: 2, perSecond: true): '');
+                                    $component->state(! blank($record->upload) ? Number::fileSizeBits(bits: $record->upload_bits, precision: 2, perSecond: true) : '');
                                 }),
                             Forms\Components\TextInput::make('ping')
                                 ->label('Ping (Ms)'),

--- a/app/Helpers/Number.php
+++ b/app/Helpers/Number.php
@@ -16,8 +16,8 @@ class Number extends SupportNumber
             default => ['B', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb']
         };
 
-        for ($i = 0; ($bits / 1024) > 0.9 && ($i < count($units) - 1); $i++) {
-            $bits /= 1024;
+        for ($i = 0; ($bits / 1000) > 0.9 && ($i < count($units) - 1); $i++) {
+            $bits /= 1000;
         }
 
         return sprintf('%s %s', static::format($bits, $precision, $maxPrecision), $units[$i]);


### PR DESCRIPTION
## 📃 Description

This PR fixes a calc error on the dashboard and table views. This **does not** address the API where values are being passed to Homepage or Heimdall yet.

- mentioned in #1176
- closes #1169 
- closes #1180 

## 🪵 Changelog

### ✏️ Changed

- use `Number` helper on results table

### 🔧 Fixed

- when converting bits use the power of 1000 not 1024 (for bytes)
