### PR TITLE
Milliseconds should be indicated with "ms" and not "Ms"

### DIFF
--- a/app/Filament/Pages/Settings/ThresholdsPage.php
+++ b/app/Filament/Pages/Settings/ThresholdsPage.php
@@ -78,7 +78,7 @@ class ThresholdsPage extends SettingsPage
                                                             ->required(),
                                                         Forms\Components\TextInput::make('absolute_ping')
                                                             ->label('Ping')
-                                                            ->hint('Ms')
+                                                            ->hint('ms')
                                                             ->helperText('Set to zero to disable this metric.')
                                                             ->default(0)
                                                             ->minValue(0)

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -67,13 +67,13 @@ class ResultResource extends Resource
                                     $component->state(! blank($record->upload) ? Number::fileSizeBits(bits: $record->upload_bits, precision: 2, perSecond: true) : '');
                                 }),
                             Forms\Components\TextInput::make('ping')
-                                ->label('Ping (Ms)'),
+                                ->label('Ping (ms)'),
                             Forms\Components\TextInput::make('data.download.latency.jitter')
-                                ->label('Download Jitter (Ms)'),
+                                ->label('Download Jitter (ms)'),
                             Forms\Components\TextInput::make('data.upload.latency.jitter')
-                                ->label('Upload Jitter (Ms)'),
+                                ->label('Upload Jitter (ms)'),
                             Forms\Components\TextInput::make('data.ping.jitter')
-                                ->label('Ping Jitter (Ms)'),
+                                ->label('Ping Jitter (ms)'),
                             Forms\Components\Textarea::make('data.message')
                                 ->label('Error Message')
                                 ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/help/error-messages" target="_blank" rel="nofollow">Error Messages</a>'))

--- a/app/Filament/Widgets/StatsOverviewWidget.php
+++ b/app/Filament/Widgets/StatsOverviewWidget.php
@@ -49,7 +49,7 @@ class StatsOverviewWidget extends BaseWidget
                     ->icon('heroicon-o-arrow-down-tray'),
                 Stat::make('Latest upload', fn (): string => ! blank($this->result) ? Number::fileSizeBits(bits: $this->result->upload_bits, precision: 2, perSecond: true) : 'n/a')
                     ->icon('heroicon-o-arrow-up-tray'),
-                Stat::make('Latest ping', fn (): string => ! blank($this->result) ? number_format($this->result->ping, 2).' Ms' : 'n/a')
+                Stat::make('Latest ping', fn (): string => ! blank($this->result) ? number_format($this->result->ping, 2).' ms' : 'n/a')
                     ->icon('heroicon-o-clock'),
             ];
         }
@@ -69,7 +69,7 @@ class StatsOverviewWidget extends BaseWidget
                 ->description($uploadChange > 0 ? $uploadChange.'% faster' : abs($uploadChange).'% slower')
                 ->descriptionIcon($uploadChange > 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')
                 ->color($uploadChange > 0 ? 'success' : 'danger'),
-            Stat::make('Latest ping', fn (): string => ! blank($this->result) ? number_format($this->result->ping, 2).' Ms' : 'n/a')
+            Stat::make('Latest ping', fn (): string => ! blank($this->result) ? number_format($this->result->ping, 2).' ms' : 'n/a')
                 ->icon('heroicon-o-clock')
                 ->description($pingChange > 0 ? $pingChange.'% slower' : abs($pingChange).'% faster')
                 ->descriptionIcon($pingChange > 0 ? 'heroicon-m-arrow-trending-up' : 'heroicon-m-arrow-trending-down')

--- a/app/Listeners/Threshold/AbsoluteListener.php
+++ b/app/Listeners/Threshold/AbsoluteListener.php
@@ -146,8 +146,8 @@ class AbsoluteListener implements ShouldQueue
             if (absolutePingThresholdFailed($this->thresholdSettings->absolute_ping, $event->result->ping)) {
                 array_push($failedThresholds, [
                     'name' => 'Ping',
-                    'threshold' => $this->thresholdSettings->absolute_ping.' Ms',
-                    'value' => round($event->result->ping, 2).' Ms',
+                    'threshold' => $this->thresholdSettings->absolute_ping.' ms',
+                    'value' => round($event->result->ping, 2).' ms',
                 ]);
             }
         }
@@ -198,8 +198,8 @@ class AbsoluteListener implements ShouldQueue
             if (absolutePingThresholdFailed($this->thresholdSettings->absolute_ping, $event->result->ping)) {
                 array_push($failedThresholds, [
                     'name' => 'Ping',
-                    'threshold' => $this->thresholdSettings->absolute_ping.' Ms',
-                    'value' => round($event->result->ping, 2).' Ms',
+                    'threshold' => $this->thresholdSettings->absolute_ping.' ms',
+                    'value' => round($event->result->ping, 2).' ms',
                 ]);
             }
         }


### PR DESCRIPTION
## 📃 Description

Changed "Ms" with "ms" to indicate millisecond(s) because Ms means megasecond(s) (1 Ms = 10<sup>6</sup> seconds) ([source](https://en.wikipedia.org/wiki/Metric_prefix#List_of_SI_prefixes))

## 🪵 Changelog

- "Ms" => "ms"

### ✏️ Changed

All "Ms" occurrencies with "ms" across multiple files

## 📷 Screenshots

| Before | After |
| :---: | :---: |
| ![immagine](https://github.com/alexjustesen/speedtest-tracker/assets/30187360/d16df148-e5e6-4665-be1b-976354a4bbea) | ![immagine](https://github.com/alexjustesen/speedtest-tracker/assets/30187360/1792b996-70be-4539-8ce2-cd01af54d318) |