### PR TITLE
[Bug] Return latest speedtest download and upload in mbits

### DIFF
--- a/app/Helpers/Number.php
+++ b/app/Helpers/Number.php
@@ -23,7 +23,7 @@ class Number extends SupportNumber
             default => $bits,
         };
 
-        return static::format($value, $precision);
+        return round(num: $value, precision: $precision);
     }
 
     /**

--- a/app/Http/Controllers/API/Speedtest/GetLatestController.php
+++ b/app/Http/Controllers/API/Speedtest/GetLatestController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\Speedtest;
 
 use App\Enums\ResultStatus;
+use App\Helpers\Number;
 use App\Http\Controllers\Controller;
 use App\Models\Result;
 use Illuminate\Http\JsonResponse;
@@ -30,8 +31,8 @@ class GetLatestController extends Controller
             'data' => [
                 'id' => $latest->id,
                 'ping' => $latest->ping,
-                'download' => $latest->download_bits,
-                'upload' => $latest->upload_bits,
+                'download' => ! blank($latest->download) ? Number::bitsToMagnitude(bits: $latest->download_bits, precision: 2, magnitude: 'mbit') : null,
+                'upload' => ! blank($latest->upload) ? Number::bitsToMagnitude(bits: $latest->upload_bits, precision: 2, magnitude: 'mbit') : null,
                 'server_id' => $latest->server_id,
                 'server_host' => $latest->server_host,
                 'server_name' => $latest->server_name,

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,10 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
+/**
+ * This route provides backwards compatibility https://github.com/henrywhitaker3/Speedtest-Tracker
+ * for Homepage and Organizr dashboards which expects the returned
+ * download and upload values in mbits.
+ */
 Route::get('/speedtest/latest', GetLatestController::class)
     ->name('speedtest.latest');

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,7 +20,7 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 /**
- * This route provides backwards compatibility https://github.com/henrywhitaker3/Speedtest-Tracker
+ * This route provides backwards compatibility from https://github.com/henrywhitaker3/Speedtest-Tracker
  * for Homepage and Organizr dashboards which expects the returned
  * download and upload values in mbits.
  */


### PR DESCRIPTION
## 🪵 Changelog

### 🔧 Fixed

- return `download` and `upload` values as mbit magnitude for Homepage and Organizr dashboards. closes #1176 
