### PR TITLE
[Chore] Round order of magnitude at 9 hundredths instead of tenths

### DIFF
--- a/app/Helpers/Number.php
+++ b/app/Helpers/Number.php
@@ -35,7 +35,7 @@ class Number extends SupportNumber
     {
         $units = ['B', 'Kb', 'Mb', 'Gb', 'Tb', 'Pb', 'Eb', 'Zb', 'Yb'];
 
-        for ($i = 0; ($bits / 1000) > 0.9 && ($i < count($units) - 1); $i++) {
+        for ($i = 0; ($bits / 1000) > 0.99 && ($i < count($units) - 1); $i++) {
             $bits /= 1000;
         }
 
@@ -51,7 +51,7 @@ class Number extends SupportNumber
     {
         $units = ['Bps', 'Kbps', 'Mbps', 'Gbps', 'Tbps', 'Pbps', 'Ebps', 'Zbps', 'Ybps'];
 
-        for ($i = 0; ($bits / 1000) > 0.9 && ($i < count($units) - 1); $i++) {
+        for ($i = 0; ($bits / 1000) > 0.99 && ($i < count($units) - 1); $i++) {
             $bits /= 1000;
         }
 


### PR DESCRIPTION
## 🪵 Changelog

### ✏️ Changed

- round order of magnitude at `> 0.99` vs `> 0.9`

## 📷 Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/1c85c7e7-ffe7-4b1f-bf3b-13238f528fc0)
