### PR TITLE
[CHore] Refactored discord webhooks to use WebhookCall

### DIFF
--- a/app/Actions/Notifications/SendDiscordTestNotification.php
+++ b/app/Actions/Notifications/SendDiscordTestNotification.php
@@ -3,8 +3,8 @@
 namespace App\Actions\Notifications;
 
 use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\Http;
 use Lorisleiva\Actions\Concerns\AsAction;
+use Spatie\WebhookServer\WebhookCall;
 
 class SendDiscordTestNotification
 {
@@ -14,7 +14,7 @@ class SendDiscordTestNotification
     {
         if (! count($webhooks)) {
             Notification::make()
-                ->title('You need to add webhook urls!')
+                ->title('You need to add Discord urls!')
                 ->warning()
                 ->send();
 
@@ -22,12 +22,11 @@ class SendDiscordTestNotification
         }
 
         foreach ($webhooks as $webhook) {
-            $payload = [
-                'content' => '👋 Testing the Discord notification channel.',
-            ];
-
-            // Send the request using Laravel's HTTP client
-            $response = Http::post($webhook['discord_webhook_url'], $payload);
+            WebhookCall::create()
+                ->url($webhook['discord_webhook_url'])
+                ->payload(['content' => '👋 Testing the Discord notification channel.'])
+                ->doNotSign()
+                ->dispatch();
         }
 
         Notification::make()

--- a/app/Actions/Notifications/SendDiscordTestNotification.php
+++ b/app/Actions/Notifications/SendDiscordTestNotification.php
@@ -23,7 +23,7 @@ class SendDiscordTestNotification
 
         foreach ($webhooks as $webhook) {
             WebhookCall::create()
-                ->url($webhook['discord_webhook_url'])
+                ->url($webhook['url'])
                 ->payload(['content' => '👋 Testing the Discord notification channel.'])
                 ->doNotSign()
                 ->dispatch();

--- a/app/Actions/Notifications/SendWebhookTestNotification.php
+++ b/app/Actions/Notifications/SendWebhookTestNotification.php
@@ -10,9 +10,9 @@ class SendWebhookTestNotification
 {
     use AsAction;
 
-    public function handle(array $urls)
+    public function handle(array $webhooks)
     {
-        if (! count($urls)) {
+        if (! count($webhooks)) {
             Notification::make()
                 ->title('You need to add webhook urls!')
                 ->warning()
@@ -21,9 +21,9 @@ class SendWebhookTestNotification
             return;
         }
 
-        foreach ($urls as $url) {
+        foreach ($webhooks as $webhook) {
             WebhookCall::create()
-                ->url($url['url'])
+                ->url($webhook['url'])
                 ->payload(['message' => '👋 Testing the Webhook notification channel.'])
                 ->doNotSign()
                 ->dispatch();

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -109,9 +109,10 @@ class NotificationPage extends SettingsPage
                                                 Forms\Components\Repeater::make('discord_webhooks')
                                                     ->label('Webhooks')
                                                     ->schema([
-                                                        Forms\Components\TextInput::make('discord_webhook_url')
-                                                            ->label('Webhook URL')
-                                                            ->required(),
+                                                        Forms\Components\TextInput::make('url')
+                                                            ->maxLength(2000)
+                                                            ->required()
+                                                            ->url(),
                                                     ])
                                                     ->columnSpanFull(),
                                                 Forms\Components\Actions::make([
@@ -251,7 +252,7 @@ class NotificationPage extends SettingsPage
                                                 Forms\Components\Actions::make([
                                                     Forms\Components\Actions\Action::make('test webhook')
                                                         ->label('Test webhook channel')
-                                                        ->action(fn (Forms\Get $get) => SendWebhookTestNotification::run(urls: $get('webhook_urls')))
+                                                        ->action(fn (Forms\Get $get) => SendWebhookTestNotification::run(webhooks: $get('webhook_urls')))
                                                         ->hidden(fn (Forms\Get $get) => ! count($get('webhook_urls'))),
                                                 ]),
                                             ]),


### PR DESCRIPTION
## 📃 Description

This PR does a little 🧹 cleaning when posting to the Discord webhook url.

## 🪵 Changelog

### ✏️ Changed

- standardized use of `webhooks` and `url` across Discord and Webhook notifications.
- use `Spatie\WebhookServer\WebhookCall` for sending a webhook instead of Laravel's `Http` client.
