### PR TITLE
[Feature] Added heathcheck API route

### DIFF
--- a/app/Http/Controllers/API/HealthCheckController.php
+++ b/app/Http/Controllers/API/HealthCheckController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers\API;
+
+use App\Http\Controllers\Controller;
+
+class HealthCheckController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke()
+    {
+        return response()->json([
+            'message' => 'Speedtest Tracker is running!',
+        ]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\API\HealthCheckController;
 use App\Http\Controllers\API\Speedtest\GetLatestController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -18,6 +19,8 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/healthcheck', HealthCheckController::class);
 
 /**
  * This route provides backwards compatibility from https://github.com/henrywhitaker3/Speedtest-Tracker


### PR DESCRIPTION
## 📃 Description

With the switch to LSIO image `/ping` is no longer available, this PR provides a `/api/healthcheck` route that returns a `200` code response with a json message.

```json
{"message":"Speedtest Tracker is running!"}
```

## 🪵 Changelog

### ➕ Added

- `/api/healthcheck` route that can be used to monitor if the application is up, closes #1228 

