### PR TITLE
[Chore] Refactored Discord notifications to use WebhookCall

### DIFF
--- a/app/Listeners/SpeedtestCompletedListener.php
+++ b/app/Listeners/SpeedtestCompletedListener.php
@@ -8,7 +8,6 @@ use App\Settings\GeneralSettings;
 use App\Settings\NotificationSettings;
 use App\Telegram\TelegramNotification;
 use Filament\Notifications\Notification;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Mail;
 use Spatie\WebhookServer\WebhookCall;
 
@@ -88,8 +87,13 @@ class SpeedtestCompletedListener
                                         "\nDownload: ".($event->result->downloadBits / 1000000).' (Mbps)'.
                                         "\nUpload: ".($event->result->uploadBits / 1000000).' (Mbps)',
                     ];
-                    // Send the request using Laravel's HTTP client
-                    $response = Http::post($webhook['url'], $payload);
+                    // Send the payload using WebhookCall
+                    WebhookCall::create()
+                        ->url($webhook['url'])
+                        ->payload($payload)
+                        ->doNotSign()
+                        ->dispatch();
+
                 }
             }
         }

--- a/app/Listeners/Threshold/AbsoluteListener.php
+++ b/app/Listeners/Threshold/AbsoluteListener.php
@@ -265,8 +265,13 @@ class AbsoluteListener implements ShouldQueue
                             'content' => implode("\n", $contentLines),
                         ];
 
-                        // Send the request using Laravel's HTTP client
-                        $response = Http::post($webhook['url'], $payload);
+                        // Send the payload using WebhookCall
+                        WebhookCall::create()
+                            ->url($webhook['url'])
+                            ->payload($payload)
+                            ->doNotSign()
+                            ->dispatch();
+
                     }
                 }
             }


### PR DESCRIPTION
## 📃 Description

Refactored Discord notifications to use WebhookCall

## 🪵 Changelog

### ➕ Added

N/A

### ✏️ Changed

- Updated `app/Listeners/Threshold/AbsoluteListener.php` to use `WebhookCall` instead of Laravel's `http` to send the payload
- Updated `app/Listeners/SpeedtestCompletedListener.php` to use `WebhookCall` instead of Laravel's `http` to send the payload

### 🔧 Fixed

N/A

### 🗑️ Removed

- Removed imports of Laravel's `http` 

## 📷 Screenshots

No frontend modifications were made
