### PR TITLE
[Bug] Don't proceed with notifications if absolute threshold disabled

### DIFF
--- a/app/Listeners/Database/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Database/SendSpeedtestThresholdNotification.php
@@ -18,13 +18,17 @@ class SendSpeedtestThresholdNotification
     {
         $notificationSettings = new NotificationSettings();
 
-        $thresholdSettings = new ThresholdSettings();
-
         if (! $notificationSettings->database_enabled) {
             return;
         }
 
         if (! $notificationSettings->database_on_threshold_failure) {
+            return;
+        }
+
+        $thresholdSettings = new ThresholdSettings();
+
+        if (! $thresholdSettings->absolute_enabled) {
             return;
         }
 

--- a/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
@@ -35,6 +35,10 @@ class SendSpeedtestThresholdNotification
 
         $thresholdSettings = new ThresholdSettings();
 
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
         $failed = [];
 
         if ($thresholdSettings->absolute_download > 0) {
@@ -50,6 +54,8 @@ class SendSpeedtestThresholdNotification
         }
 
         if (! count($failed)) {
+            Log::warning('Failed Discord thresholds not found, won\'t send notification.');
+
             return;
         }
 

--- a/app/Listeners/Mail/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Mail/SendSpeedtestThresholdNotification.php
@@ -35,6 +35,10 @@ class SendSpeedtestThresholdNotification
 
         $thresholdSettings = new ThresholdSettings();
 
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
         $failed = [];
 
         if ($thresholdSettings->absolute_download > 0) {
@@ -50,6 +54,8 @@ class SendSpeedtestThresholdNotification
         }
 
         if (! count($failed)) {
+            Log::warning('Failed mail thresholds not found, won\'t send notification.');
+
             return;
         }
 

--- a/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
@@ -36,6 +36,10 @@ class SendSpeedtestThresholdNotification
 
         $thresholdSettings = new ThresholdSettings();
 
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
         $failed = [];
 
         if ($thresholdSettings->absolute_download > 0) {
@@ -51,6 +55,8 @@ class SendSpeedtestThresholdNotification
         }
 
         if (! count($failed)) {
+            Log::warning('Failed Telegram thresholds not found, won\'t send notification.');
+
             return;
         }
 

--- a/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
@@ -37,6 +37,10 @@ class SendSpeedtestThresholdNotification
 
         $thresholdSettings = new ThresholdSettings();
 
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
         $failed = [];
 
         if ($thresholdSettings->absolute_download > 0) {
@@ -52,6 +56,8 @@ class SendSpeedtestThresholdNotification
         }
 
         if (! count($failed)) {
+            Log::warning('Failed webhook thresholds not found, won\'t send notification.');
+
             return;
         }
 


### PR DESCRIPTION
## 🪵 Changelog

### ➕ Added

- additional log messages when a listener stops because of missing data

### 🔧 Fixed

- don't proceed with notification if absolute threshold disabled
