### PR TITLE
[Bug] Don't try to send empty threshold notifications

### DIFF
--- a/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
@@ -53,6 +53,8 @@ class SendSpeedtestThresholdNotification
             array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
         }
 
+        $failed = array_filter($failed);
+
         if (! count($failed)) {
             Log::warning('Failed Discord thresholds not found, won\'t send notification.');
 
@@ -81,10 +83,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Discord notification if absolute download threshold is breached.
      */
-    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
-            return [];
+            return false;
         }
 
         return [
@@ -97,10 +99,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Discord notification if absolute upload threshold is breached.
      */
-    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
-            return [];
+            return false;
         }
 
         return [
@@ -113,10 +115,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Discord notification if absolute ping threshold is breached.
      */
-    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
-            return [];
+            return false;
         }
 
         return [

--- a/app/Listeners/Mail/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Mail/SendSpeedtestThresholdNotification.php
@@ -53,6 +53,8 @@ class SendSpeedtestThresholdNotification
             array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
         }
 
+        $failed = array_filter($failed);
+
         if (! count($failed)) {
             Log::warning('Failed mail thresholds not found, won\'t send notification.');
 
@@ -68,10 +70,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build mail notification if absolute download threshold is breached.
      */
-    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
-            return [];
+            return false;
         }
 
         return [
@@ -84,10 +86,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build mail notification if absolute upload threshold is breached.
      */
-    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
-            return [];
+            return false;
         }
 
         return [
@@ -100,10 +102,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build mail notification if absolute ping threshold is breached.
      */
-    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
-            return [];
+            return false;
         }
 
         return [

--- a/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
@@ -54,6 +54,8 @@ class SendSpeedtestThresholdNotification
             array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
         }
 
+        $failed = array_filter($failed);
+
         if (! count($failed)) {
             Log::warning('Failed Telegram thresholds not found, won\'t send notification.');
 
@@ -77,10 +79,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Telegram notification if absolute download threshold is breached.
      */
-    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
-            return [];
+            return false;
         }
 
         return [
@@ -93,10 +95,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Telegram notification if absolute upload threshold is breached.
      */
-    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
-            return [];
+            return false;
         }
 
         return [
@@ -109,10 +111,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build Telegram notification if absolute ping threshold is breached.
      */
-    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
-            return [];
+            return false;
         }
 
         return [

--- a/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
@@ -55,6 +55,8 @@ class SendSpeedtestThresholdNotification
             array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
         }
 
+        $failed = array_filter($failed);
+
         if (! count($failed)) {
             Log::warning('Failed webhook thresholds not found, won\'t send notification.');
 
@@ -77,10 +79,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build webhook notification if absolute download threshold is breached.
      */
-    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
-            return [];
+            return false;
         }
 
         return [
@@ -93,10 +95,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build webhook notification if absolute upload threshold is breached.
      */
-    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
-            return [];
+            return false;
         }
 
         return [
@@ -109,10 +111,10 @@ class SendSpeedtestThresholdNotification
     /**
      * Build webhook notification if absolute ping threshold is breached.
      */
-    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): array
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
     {
         if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
-            return [];
+            return false;
         }
 
         return [

--- a/resources/views/emails/speedtest-completed.blade.php
+++ b/resources/views/emails/speedtest-completed.blade.php
@@ -5,7 +5,7 @@ A new speedtest was completed using **{{ $service }}**.
 
 <x-mail::table>
 | **Metric**  | **Value**         |
-|-------------|------------------:|
+|:------------|------------------:|
 | Server name | {{ $serverName }} |
 | Server ID   | {{ $serverId }}   |
 | Ping        | {{ $ping }}       |

--- a/resources/views/emails/speedtest-threshold.blade.php
+++ b/resources/views/emails/speedtest-threshold.blade.php
@@ -5,7 +5,7 @@ A new speedtest was completed using **{{ $service }}** but a threshold was breac
 
 <x-mail::table>
 | **Metric** | **Threshold** | **Value** |
-|------------|--------------:|----------:|
+|:-----------|:--------------|----------:|
 @foreach ($metrics as $item)
 | {{ $item['name'] }} | {{ $item['threshold'] }} | {{ $item['value'] }} |
 @endforeach


### PR DESCRIPTION
## 📜 Description

- closes #1281 
- closes #1290 

## 🪵 Changelog

### 🔧 Fixed

- don't try to send empty threshold notifications
