### PR TITLE
[Feature] Added packet loss to form view and table

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -74,6 +74,8 @@ class ResultResource extends Resource
                                 ->label('Upload Jitter (ms)'),
                             Forms\Components\TextInput::make('data.ping.jitter')
                                 ->label('Ping Jitter (ms)'),
+                            Forms\Components\TextInput::make('data.packetLoss')
+                                ->label('Packet Loss'),
                             Forms\Components\Textarea::make('data.message')
                                 ->label('Error Message')
                                 ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/help/error-messages" target="_blank" rel="nofollow">Error Messages</a>'))
@@ -163,6 +165,9 @@ class ResultResource extends Resource
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->ping->jitter', $direction);
                     }),
+                Tables\Columns\TextColumn::make('packet_loss')
+                    ->toggleable()
+                    ->toggledHiddenByDefault(),
                 Tables\Columns\TextColumn::make('status')
                     ->toggleable()
                     ->sortable(),


### PR DESCRIPTION
## 📃 Description

This PR adds packet loss to the form view and table, worth noting it doesn't seem like all servers return the packet loss metric.

## 🪵 Changelog

### ➕ Added

- packet loss metric, closes #1298 
