### PR TITLE
[Chore] Deprecate general settings site name

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -49,8 +49,8 @@ class GeneralPage extends SettingsPage
                         Forms\Components\Section::make('Site Settings')
                             ->schema([
                                 Forms\Components\TextInput::make('site_name')
-                                    ->maxLength(50)
-                                    ->required()
+                                    ->disabled()
+                                    ->helperText(new HtmlString('⚠️ DEPRECATED: Use <code>APP_NAME</code> environment variable.'))
                                     ->columnSpanFull(),
                                 Forms\Components\Toggle::make('public_dashboard_enabled')
                                     ->label('Public dashboard'),

--- a/app/Listeners/Webhook/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestCompletedNotification.php
@@ -3,7 +3,6 @@
 namespace App\Listeners\Webhook;
 
 use App\Events\SpeedtestCompleted;
-use App\Settings\GeneralSettings;
 use App\Settings\NotificationSettings;
 use Illuminate\Support\Facades\Log;
 use Spatie\WebhookServer\WebhookCall;
@@ -15,8 +14,6 @@ class SendSpeedtestCompletedNotification
      */
     public function handle(SpeedtestCompleted $event): void
     {
-        $generalSettings = new GeneralSettings();
-
         $notificationSettings = new NotificationSettings();
 
         if (! $notificationSettings->webhook_enabled) {
@@ -38,7 +35,7 @@ class SendSpeedtestCompletedNotification
                 ->url($url['url'])
                 ->payload([
                     'result_id' => $event->result->id,
-                    'site_name' => $generalSettings->site_name,
+                    'site_name' => config('app.name'),
                     'ping' => $event->result->ping,
                     'download' => $event->result->downloadBits,
                     'upload' => $event->result->uploadBits,

--- a/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
@@ -4,7 +4,6 @@ namespace App\Listeners\Webhook;
 
 use App\Events\SpeedtestCompleted;
 use App\Helpers\Number;
-use App\Settings\GeneralSettings;
 use App\Settings\NotificationSettings;
 use App\Settings\ThresholdSettings;
 use Illuminate\Support\Facades\Log;
@@ -32,8 +31,6 @@ class SendSpeedtestThresholdNotification
 
             return;
         }
-
-        $generalSettings = new GeneralSettings();
 
         $thresholdSettings = new ThresholdSettings();
 
@@ -68,7 +65,7 @@ class SendSpeedtestThresholdNotification
                 ->url($url['url'])
                 ->payload([
                     'result_id' => $event->result->id,
-                    'site_name' => $generalSettings->site_name,
+                    'site_name' => config('app.name'),
                     'metrics' => $failed,
                 ])
                 ->doNotSign()

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -15,6 +15,9 @@ class GeneralSettings extends Settings
     /** @var string[] */
     public $speedtest_server;
 
+    /**
+     * @deprecated Use APP_NAME environment variable.
+     */
     public string $site_name;
 
     public string $time_format;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -62,7 +62,7 @@ if (! function_exists('absolutePingThresholdFailed')) {
  * @deprecated
  *
  * @param  string  $data
- * @return  bool
+ * @return bool
  */
 if (! function_exists('json_validate')) {
     function json_validate($data)


### PR DESCRIPTION
## 📃 Description

This PR deprecates general settings `site_name` variable as part of the work detailed in #1258.

## ✅ To-dos

- [x] update [environment variable](https://docs.speedtest-tracker.dev/getting-started/environment-variables) docs

## 🪵 Changelog

### ✏️ Changed

- use `config('app.name')` in notifications

### 🗑️ Removed

- deprecated `site_name` from general settings
