### PR TITLE
[Chore] Deprecate general settings public dashboard

### DIFF
--- a/app/Console/Commands/UpdateGeneralSettings.php
+++ b/app/Console/Commands/UpdateGeneralSettings.php
@@ -8,6 +8,7 @@ use Cron\CronExpression;
 use Illuminate\Console\Command;
 
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
 class UpdateGeneralSettings extends Command
@@ -34,6 +35,7 @@ class UpdateGeneralSettings extends Command
         $settings = new GeneralSettings();
 
         $this->updateSiteName($settings);
+        $this->updatePublicDashboard($settings);
         $this->updateTimeZone($settings);
         $this->updateSchedule($settings);
         $this->resetSevers($settings);
@@ -57,12 +59,32 @@ class UpdateGeneralSettings extends Command
         }
     }
 
+    protected function updatePublicDashboard($settings): void
+    {
+        $publicDashboard = select(
+            label: 'Make the dashboard public?',
+            options: ['Yes', 'No'],
+            default: 'Yes',
+            required: true,
+        );
+
+        if ($publicDashboard == 'Yes') {
+            $settings->public_dashboard_enabled = true;
+
+            $settings->save();
+        } else {
+            $settings->public_dashboard_enabled = false;
+        }
+
+        $settings->save();
+    }
+
     protected function updateSchedule($settings): void
     {
         $cron = text(
             label: 'What is the schedule?',
             placeholder: '0 * * * *',
-            default: $settings->speedtest_schedule,
+            default: $settings->speedtest_schedule ?? '0 * * * *',
             required: true,
             validate: fn (string $value) => match (true) {
                 ! CronExpression::isValidExpression($value) => 'The schedule expression is invalid.',

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -13,7 +13,6 @@ use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
 use Filament\Pages\Dashboard as BasePage;
-use Filament\Support\Enums\ActionSize;
 use Filament\Support\Enums\IconPosition;
 use Illuminate\Support\Arr;
 
@@ -30,9 +29,11 @@ class Dashboard extends BasePage
         return [
             Action::make('home')
                 ->label('Public Dashboard')
+                ->icon('heroicon-o-chart-bar')
+                ->iconPosition(IconPosition::Before)
                 ->color('gray')
-                ->hidden(fn (GeneralSettings $settings): bool => ! $settings->public_dashboard_enabled)
-                ->url('/'),
+                ->hidden(fn (): bool => !config('speedtest.public_dashboard'))
+                ->url(shouldOpenInNewTab: true, url: '/'),
             ActionGroup::make([
                 Action::make('ookla speedtest')
                     ->action(function (GeneralSettings $settings) {
@@ -55,9 +56,8 @@ class Dashboard extends BasePage
                 ->dropdownPlacement('bottom-end')
                 ->label('Run Speedtest')
                 ->icon('heroicon-o-rocket-launch')
-                ->iconPosition(IconPosition::After)
-                ->hidden(! auth()->user()->is_admin)
-                ->size(ActionSize::Small),
+                ->iconPosition(IconPosition::Before)
+                ->hidden(! auth()->user()->is_admin),
         ];
     }
 

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -32,7 +32,7 @@ class Dashboard extends BasePage
                 ->icon('heroicon-o-chart-bar')
                 ->iconPosition(IconPosition::Before)
                 ->color('gray')
-                ->hidden(fn (): bool => !config('speedtest.public_dashboard'))
+                ->hidden(fn (): bool => ! config('speedtest.public_dashboard'))
                 ->url(shouldOpenInNewTab: true, url: '/'),
             ActionGroup::make([
                 Action::make('ookla speedtest')

--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -53,7 +53,9 @@ class GeneralPage extends SettingsPage
                                     ->helperText(new HtmlString('⚠️ DEPRECATED: Use <code>APP_NAME</code> environment variable.'))
                                     ->columnSpanFull(),
                                 Forms\Components\Toggle::make('public_dashboard_enabled')
-                                    ->label('Public dashboard'),
+                                    ->label('Public dashboard')
+                                    ->disabled()
+                                    ->helperText(new HtmlString('⚠️ DEPRECATED: Use <code>PUBLIC_DASHBOARD</code> environment variable.')),
                             ])
                             ->compact()
                             ->columns([

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -16,7 +16,7 @@ class HomeController extends Controller
     {
         $settings = new GeneralSettings();
 
-        if (! $settings->public_dashboard_enabled) {
+        if (! config('speedtest.public_dashboard')) {
             return redirect()->route('filament.admin.auth.login');
         }
 

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -26,6 +26,9 @@ class GeneralSettings extends Settings
 
     public bool $db_has_timezone;
 
+    /**
+     * @deprecated Use PUBLIC_DASHBOARD environment variable.
+     */
     public bool $public_dashboard_enabled;
 
     public static function group(): string

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -15,6 +15,8 @@ return [
      */
     'content_width' => env('CONTENT_WIDTH', '7xl'),
 
+    'public_dashboard' => env('PUBLIC_DASHBOARD', false),
+
     /**
      * Polling
      */


### PR DESCRIPTION
## 📃 Description

This PR deprecated general settings enable public dashboard detailed in #1258.

## ✅ To-dos

- [x] update the [environment variable](https://docs.speedtest-tracker.dev/getting-started/environment-variables) docs.

## 🪵 Changelog

### ➕ Added

- `public_dashboard` environment variable

### 🗑️ Removed

- deprecated general settings enable public dashboard 
