### PR TITLE
[Bug] Use can access method for pages

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -20,8 +20,6 @@ class Dashboard extends BasePage
 {
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
 
-    protected static ?int $navigationSort = 1;
-
     protected static string $view = 'filament.pages.dashboard';
 
     protected function getHeaderActions(): array

--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -26,11 +26,9 @@ class GeneralPage extends SettingsPage
 
     protected static string $settings = GeneralSettings::class;
 
-    public function mount(): void
+    public static function canAccess(): bool
     {
-        parent::mount();
-
-        abort_unless(auth()->user()->is_admin, 403);
+        return auth()->user()->is_admin;
     }
 
     public static function shouldRegisterNavigation(): bool

--- a/app/Filament/Pages/Settings/InfluxDbPage.php
+++ b/app/Filament/Pages/Settings/InfluxDbPage.php
@@ -21,11 +21,9 @@ class InfluxDbPage extends SettingsPage
 
     protected static string $settings = InfluxDbSettings::class;
 
-    public function mount(): void
+    public static function canAccess(): bool
     {
-        parent::mount();
-
-        abort_unless(auth()->user()->is_admin, 403);
+        return auth()->user()->is_admin;
     }
 
     public static function shouldRegisterNavigation(): bool

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -27,11 +27,9 @@ class NotificationPage extends SettingsPage
 
     protected static string $settings = NotificationSettings::class;
 
-    public function mount(): void
+    public static function canAccess(): bool
     {
-        parent::mount();
-
-        abort_unless(auth()->user()->is_admin, 403);
+        return auth()->user()->is_admin;
     }
 
     public static function shouldRegisterNavigation(): bool

--- a/app/Filament/Pages/Settings/ThresholdsPage.php
+++ b/app/Filament/Pages/Settings/ThresholdsPage.php
@@ -21,11 +21,9 @@ class ThresholdsPage extends SettingsPage
 
     protected static string $settings = ThresholdSettings::class;
 
-    public function mount(): void
+    public static function canAccess(): bool
     {
-        parent::mount();
-
-        abort_unless(auth()->user()->is_admin, 403);
+        return auth()->user()->is_admin;
     }
 
     public static function shouldRegisterNavigation(): bool

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -31,8 +31,6 @@ class ResultResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-table-cells';
 
-    protected static ?int $navigationSort = 2;
-
     public static function form(Form $form): Form
     {
         $settings = new GeneralSettings();

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -21,8 +21,6 @@ class UserResource extends Resource
 
     protected static ?string $navigationIcon = 'heroicon-o-users';
 
-    protected static ?int $navigationSort = 3;
-
     public static function form(Form $form): Form
     {
         return $form


### PR DESCRIPTION
## 🪵 Changelog

### 🔧 Fixed

- use `canAccess()` method for pages instead of hooking into the `mount()` method. closes #1226 

### 🗑️ Removed

- page nav order, not needed.
