### PR TITLE
[Feature] Added ability to truncate the results table

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -8,6 +8,7 @@ use App\Filament\Exports\ResultExporter;
 use App\Filament\Resources\ResultResource\Pages;
 use App\Helpers\Number;
 use App\Helpers\TimeZoneHelper;
+use App\Jobs\TruncateResults;
 use App\Models\Result;
 use App\Settings\DataMigrationSettings;
 use App\Settings\GeneralSettings;
@@ -316,6 +317,16 @@ class ResultResource extends Resource
                     ->modalHeading('Migrate History')
                     ->modalDescription(new HtmlString('<p>v0.16.0 archived the old <code>"results"</code> table, to migrate your history click the button below.</p><p>For more information read the <a href="#" target="_blank" rel="nofollow" class="underline">docs</a>.</p>'))
                     ->modalSubmitActionLabel('Yes, migrate it'),
+                Tables\Actions\ActionGroup::make([
+                    Tables\Actions\Action::make('truncate')
+                        ->action(fn () => TruncateResults::dispatch(Auth::user()))
+                        ->requiresConfirmation()
+                        ->modalHeading('Truncate Results')
+                        ->modalDescription('Are you sure you want to truncate all results data? This can\'t be undone.')
+                        ->color('danger')
+                        ->icon('heroicon-o-trash')
+                        ->hidden(fn (): bool => ! Auth::user()->is_admin),
+                ])->dropdownPlacement('bottom-end'),
             ])
             ->defaultSort('created_at', 'desc')
             ->paginated([5, 15, 25, 50, 100])

--- a/app/Jobs/TruncateResults.php
+++ b/app/Jobs/TruncateResults.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Filament\Notifications\Notification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class TruncateResults implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The number of times the job may be attempted.
+     *
+     * @var int
+     */
+    public $tries = 1;
+
+    public function __construct(
+        public User $user,
+    ) {
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        try {
+            DB::table('results')->truncate();
+        } catch (\Throwable $th) {
+            $this->fail($th);
+
+            return;
+        }
+
+        Notification::make()
+            ->title('Results table truncated!')
+            ->success()
+            ->sendToDatabase($this->user);
+    }
+}


### PR DESCRIPTION
## 📃 Description

This PR adds the ability to truncate the results table. This differs from deleting records as it resets the table's primary key.

- closes #1344 

## 🪵 Changelog

### ➕ Added

- ability to truncate `results` table from the UI
