### PR TITLE
Use https://crontab.guru instead of https://crontab.cronhub.io/

### DIFF
--- a/app/Filament/Pages/Settings/GeneralPage.php
+++ b/app/Filament/Pages/Settings/GeneralPage.php
@@ -89,7 +89,7 @@ class GeneralPage extends SettingsPage
                                 Forms\Components\TextInput::make('speedtest_schedule')
                                     ->rules([new Cron()])
                                     ->helperText('Leave empty to disable scheduled tests.')
-                                    ->hint(new HtmlString('&#x1f517;<a href="https://crontab.cronhub.io/" target="_blank" rel="nofollow">Cron Generator</a>'))
+                                    ->hint(new HtmlString('&#x1f517;<a href="https://crontab.guru" target="_blank" rel="nofollow">Cron Generator</a>'))
                                     ->nullable()
                                     ->columnSpan(1),
                                 Forms\Components\TextInput::make('prune_results_older_than')


### PR DESCRIPTION
## 📃 Description

Switching to https://crontab.guru from https://crontab.cronhub.io/  as the former gives warnings for non-standard cron expressions and offers info on next run etc.

## 🪵 Changelog

### ✏️ Changed

- GeneralPage.php