### PR TITLE
[Bug] Added timezone to latest speedtest API response

### DIFF
--- a/app/Http/Controllers/API/Speedtest/GetLatestController.php
+++ b/app/Http/Controllers/API/Speedtest/GetLatestController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers\API\Speedtest;
 
 use App\Enums\ResultStatus;
 use App\Helpers\Number;
+use App\Helpers\TimeZoneHelper;
 use App\Http\Controllers\Controller;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Illuminate\Http\JsonResponse;
 
 class GetLatestController extends Controller
@@ -26,6 +28,8 @@ class GetLatestController extends Controller
             ], 404);
         }
 
+        $settings = new GeneralSettings();
+
         return response()->json([
             'message' => 'ok',
             'data' => [
@@ -39,8 +43,8 @@ class GetLatestController extends Controller
                 'url' => $latest->result_url,
                 'scheduled' => $latest->scheduled,
                 'failed' => $latest->status === ResultStatus::Failed,
-                'created_at' => $latest->created_at->toISOString(true),
-                'updated_at' => $latest->updated_at->toISOString(true),
+                'created_at' => $latest->created_at->timezone(TimeZoneHelper::displayTimeZone($settings))->toISOString(true),
+                'updated_at' => $latest->updated_at->timezone(TimeZoneHelper::displayTimeZone($settings))->toISOString(true),
             ],
         ]);
     }


### PR DESCRIPTION
## 📃 Description

This PR adds display timezone to the `/speedtest/latest` API response. Expands on the work started in #1070.

### Before

```json
{
    "message":"ok",
    "data":{
        "id":1,
        "created_at":"2024-04-10T01:41:12.000000+00:00",
        "updated_at":"2024-04-10T01:41:33.000000+00:00"
    }
}
```

### After

```json
{
    "message":"ok",
    "data":{
        "id":1,
        "created_at":"2024-04-09T21:41:12.000000-04:00",
        "updated_at":"2024-04-09T21:41:33.000000-04:00"
    }
}
```

- closes #1375 

## 🪵 Changelog

### 🔧 Fixed

- added display timezone to latest speedtest API response
