### PR TITLE
[Chore] Added deprecated image warning to admin panel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ RUN apt-get update \
     \
 # Clean up package lists
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
+# Add deprecated image file
+    && touch /var/html/www/storage/app/public/.deprecated_image
 
 # Copy package configs
 COPY --chmod=755 docker/deploy/etc /etc

--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use App\Actions\Speedtests\RunOoklaSpeedtest;
+use App\Filament\Widgets\DeprecatedImage;
 use App\Filament\Widgets\RecentDownloadChartWidget;
 use App\Filament\Widgets\RecentDownloadLatencyChartWidget;
 use App\Filament\Widgets\RecentJitterChartWidget;
@@ -64,6 +65,7 @@ class Dashboard extends BasePage
     protected function getHeaderWidgets(): array
     {
         return [
+            DeprecatedImage::make(),
             StatsOverviewWidget::make(),
             RecentDownloadChartWidget::make(),
             RecentUploadChartWidget::make(),

--- a/app/Filament/Widgets/DeprecatedImage.php
+++ b/app/Filament/Widgets/DeprecatedImage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use Filament\Widgets\Widget;
+use Illuminate\Support\Facades\Storage;
+
+class DeprecatedImage extends Widget
+{
+    protected static string $view = 'filament.widgets.deprecated-image';
+
+    protected int | string | array $columnSpan = 'full';
+
+    public static function canView(): bool
+    {
+        return Storage::disk('public')->exists('.deprecated_image');
+    }
+}

--- a/app/Filament/Widgets/DeprecatedImage.php
+++ b/app/Filament/Widgets/DeprecatedImage.php
@@ -9,7 +9,7 @@ class DeprecatedImage extends Widget
 {
     protected static string $view = 'filament.widgets.deprecated-image';
 
-    protected int | string | array $columnSpan = 'full';
+    protected int|string|array $columnSpan = 'full';
 
     public static function canView(): bool
     {

--- a/resources/views/filament/widgets/deprecated-image.blade.php
+++ b/resources/views/filament/widgets/deprecated-image.blade.php
@@ -1,0 +1,14 @@
+<x-filament-widgets::widget>
+    <x-filament::section icon="heroicon-o-exclamation-triangle" icon-color="danger" icon-size="md">
+        <x-slot name="heading">
+            Docker Image Deprecated
+        </x-slot>
+
+        <div class="text-sm font-medium text-gray-500 dark:text-gray-400">
+            <p>
+                The Docker image you're using has been deprecated and will be replaced in <code>v0.20.0</code>. To upgrade to the new image
+                follow the steps in the <x-filament::link href="https://github.com/alexjustesen/speedtest-tracker/issues/1117" target="_blank" rel="nofollow">GitHub issue</x-filament::link> to continue to receive updates.
+            </p>
+        </div>
+    </x-filament::section>
+</x-filament-widgets::widget>


### PR DESCRIPTION
## 📃 Description

This PR adds a deprecated image warning to the admin panel for anyone who hasn't switched over to the LSIO image.

- closes #1379 

## 🪵 Changelog

### ➕ Added

- deprecated image warning to admin panel for my image only

## 📷 Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/6e60a948-f7d4-46ed-b0e5-46a551394e9a)