### PR TITLE
Add Packet loss to CSV export 

### DIFF
--- a/app/Filament/Exports/ResultExporter.php
+++ b/app/Filament/Exports/ResultExporter.php
@@ -52,6 +52,7 @@ class ResultExporter extends Exporter
                     return $record->upload_bits;
                 }),
             ExportColumn::make('ping'),
+            ExportColumn::make('packet_loss'),
             ExportColumn::make('download_jitter')
                 ->state(function (Result $record): ?string {
                     return $record->download_jitter;


### PR DESCRIPTION
## 📃 Description

This PR adds the packet loss to the CSV export to close https://github.com/alexjustesen/speedtest-tracker/issues/1374

### ✏️ Changed

- Add the packet loss to the ResultExporter.php

## 📷 Screenshots

Test against multiple, when no packet loss is returned by it the field stays empty as expected 

<img width="379" alt="image" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/1de2145e-63a6-42ce-99d6-5fb8f4d83568">