### PR TITLE
removed version from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
     laravel.test:
         build:


### PR DESCRIPTION
## 🪵 Changelog

### 🗑️ Removed

- `version` is now deprecated, so it's been removed from `docker-compose.yml`
