### PR TITLE
[Feature] Unique Ookla speedtest job and increased timeout

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -16,7 +16,7 @@ use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class ExecuteOoklaSpeedtest implements ShouldQueue, ShouldBeUnique
+class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 

--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -7,6 +7,7 @@ use App\Events\SpeedtestCompleted;
 use App\Events\SpeedtestFailed;
 use App\Models\Result;
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
@@ -15,9 +16,16 @@ use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
-class ExecuteOoklaSpeedtest implements ShouldQueue
+class ExecuteOoklaSpeedtest implements ShouldQueue, ShouldBeUnique
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 120;
 
     /**
      * Create a new job instance.


### PR DESCRIPTION
## 📃 Description

This PR makes the Ookla Speedtest job unique and increases it's timeout in case of a slow connection.

## 🪵 Changelog

### ➕ Added

- Ookla Speedtest job will now be unique in the queue which will prevent stacking of jobs.

### ✏️ Changed

- increased the job timeout from 60s (default) to 120s, closes #1413 
