### PR TITLE
[Bug] Fixed updating the result record when a test fails

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -58,7 +58,7 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
 
             $message = collect(array_filter($messages, 'json_validate'))->last();
 
-            Result::create([
+            $this->result->update([
                 'data' => json_decode($message, true),
                 'status' => ResultStatus::Failed,
             ]);


### PR DESCRIPTION
## 📃 Description

When a test failed a new record would be created instead of updating the existing result record, this fixes that issue.

## 🪵 Changelog

### 🔧 Fixed

- update existing result record when a test fails, closes #1439 
