### PR TITLE
[Feature] Display next speedtest run at date on dashboard

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -11,6 +11,8 @@ use App\Filament\Widgets\RecentPingChartWidget;
 use App\Filament\Widgets\RecentUploadChartWidget;
 use App\Filament\Widgets\RecentUploadLatencyChartWidget;
 use App\Filament\Widgets\StatsOverviewWidget;
+use Carbon\Carbon;
+use Cron\CronExpression;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Notifications\Notification;
@@ -23,6 +25,19 @@ class Dashboard extends BasePage
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar';
 
     protected static string $view = 'filament.pages.dashboard';
+
+    public function getSubheading(): ?string
+    {
+        if (blank(config('speedtest.schedule'))) {
+            return __('No speedtests scheduled.');
+        }
+
+        $cronExpression = new CronExpression(config('speedtest.schedule'));
+
+        $nextRunDate = Carbon::parse($cronExpression->getNextRunDate(timeZone: config('app.display_timezone')))->format(config('app.datetime_format'));
+
+        return 'Next speedtest at: '.$nextRunDate;
+    }
 
     protected function getHeaderActions(): array
     {


### PR DESCRIPTION
## 📃 Description

This PR adds the next speedtest run at date to the dashboard header.

## 🪵 Changelog

### ➕ Added

- Next speedtest run at date in the header of the dashboard

## 📷 Screenshots

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/68fc4def-3d55-4ac6-a4e9-b8dbdaf4085b)

**With a schedule**

![image](https://github.com/alexjustesen/speedtest-tracker/assets/1144087/aba535ad-d730-48d6-bdfa-03ac9b34f3f3)

**Without a schedule**