### PR TITLE
[Feature] Added chart datetime format environment variable

### DIFF
--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -61,7 +61,7 @@ class RecentDownloadChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -80,7 +80,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -80,7 +80,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -60,7 +60,7 @@ class RecentPingChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -61,7 +61,7 @@ class RecentUploadChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -80,7 +80,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'tension' => 0.4,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format('M. j - g:ia')),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }
 

--- a/config/app.php
+++ b/config/app.php
@@ -6,6 +6,8 @@ return [
 
     'env' => env('APP_ENV', 'production'),
 
+    'chart_datetime_format' => env('CHART_DATETIME_FORMAT', 'M. j - G:i'),
+
     'datetime_format' => env('DATETIME_FORMAT', 'M. jS, Y g:ia'),
 
     'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),


### PR DESCRIPTION
## 📃 Description

This PR adds a new `CHART_DATETIME_FORMAT` environment variable to control the datetime format in charts only.

```
- CHART_DATETIME_FORMAT="M. j - G:i"
```

## 🪵 Changelog

### ➕ Added

- chart datetime format environment variable