### PR TITLE
[Feature] Use ping instead of a HTTP get request to check for internet connection

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -13,7 +13,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Facades\Http;
+use JJG\Ping;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
 
@@ -43,11 +43,14 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
     public function handle(): void
     {
         /**
-         * Check to make sure there is an internet connection first.
+         * Check for an internet connection first.
          */
-        try {
-            Http::retry(3, 500)->get('1.1.1.1');
-        } catch (\Throwable $th) {
+        $ping = new Ping(
+            host: config('speedtest.ping_url'),
+            timeout: 3,
+        );
+
+        if ($ping->ping() === false) {
             $this->result->update([
                 'data' => [
                     'type' => 'log',

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "dragonmantank/cron-expression": "^3.3.3",
         "filament/filament": "^3.2.86",
         "filament/spatie-laravel-settings-plugin": "^3.2.86",
+        "geerlingguy/ping": "^1.2.1",
         "guzzlehttp/guzzle": "^7.8.1",
         "influxdata/influxdb-client-php": "^3.5",
         "laravel-notification-channels/telegram": "^5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "496a9301fe3ad40dc4f0d06e1dc6bd59",
+    "content-hash": "91982ea4bba927383f94856194ea5266",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -1899,6 +1899,43 @@
                 }
             ],
             "time": "2023-10-12T05:21:21+00:00"
+        },
+        {
+            "name": "geerlingguy/ping",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/geerlingguy/Ping.git",
+                "reference": "e0206326e23c99e3e8820e24705f8ca517adff93"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/geerlingguy/Ping/zipball/e0206326e23c99e3e8820e24705f8ca517adff93",
+                "reference": "e0206326e23c99e3e8820e24705f8ca517adff93",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "JJG/Ping.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Geerling",
+                    "email": "jeff@jeffgeerling.com"
+                }
+            ],
+            "description": "A PHP class to ping hosts.",
+            "support": {
+                "issues": "https://github.com/geerlingguy/Ping/issues",
+                "source": "https://github.com/geerlingguy/Ping/tree/1.2.1"
+            },
+            "time": "2019-07-29T21:54:12+00:00"
         },
         {
             "name": "graham-campbell/result-type",

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -29,6 +29,8 @@ return [
     /**
      * Speedtest settings.
      */
+    'ping_url' => env('SPEEDTEST_PING_URL', '1.1.1.1'),
+
     'schedule' => env('SPEEDTEST_SCHEDULE'),
 
     'servers' => env('SPEEDTEST_SERVERS', ''),

--- a/docker/8.3/Dockerfile
+++ b/docker/8.3/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch nano cron \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils iputils-ping librsvg2-bin fswatch nano cron \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \


### PR DESCRIPTION
## 📃 Description

This PR uses `ping` to check for internet connections instead of HTTP `get` requests.

closes #1484 

## 🪵 Changelog

### ✏️ Changed

- use ping instead of http get
