### PR TITLE
[Feature] Made checking for internet connection optional

### DIFF
--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -29,7 +29,7 @@ return [
     /**
      * Speedtest settings.
      */
-    'ping_url' => env('SPEEDTEST_PING_URL', '1.1.1.1'),
+    'ping_url' => env('SPEEDTEST_PING_URL'),
 
     'schedule' => env('SPEEDTEST_SCHEDULE'),
 


### PR DESCRIPTION
## 📃 Description

This PR makes checking for an internet connection optional. If `SPEEDTEST_PING_URL` is false, empty or null it will skip the check.

closes #1501 

## 🪵 Changelog

### ✏️ Changed

- made checking for internet connection before a speedtest optional
