### PR TITLE
Adding ISP value to result, export, notifications & influxbd

### DIFF
--- a/app/Filament/Exports/ResultExporter.php
+++ b/app/Filament/Exports/ResultExporter.php
@@ -30,6 +30,12 @@ class ResultExporter extends Exporter
                     return $record->ip_address;
                 })
                 ->enabledByDefault(false),
+            ExportColumn::make('isp')
+                ->label('ISP')
+                ->state(function (Result $record): ?string {
+                    return $record->isp;
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('service'),
             ExportColumn::make('server_id')
                 ->label('Server ID')

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -99,6 +99,9 @@ class ResultResource extends Resource
                             Forms\Components\Placeholder::make('server_id')
                                 ->label('Server ID')
                                 ->content(fn (Result $result): ?string => $result->server_id),
+                            Forms\Components\Placeholder::make('isp')
+                                ->label('ISP')
+                                ->content(fn (Result $result): ?string => $result->isp),
                             Forms\Components\Placeholder::make('server_host')
                                 ->content(fn (Result $result): ?string => $result->server_host),
                             Forms\Components\Checkbox::make('scheduled'),
@@ -137,6 +140,13 @@ class ResultResource extends Resource
                     ->toggleable()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->server->id', $direction);
+                    }),
+                Tables\Columns\TextColumn::make('data.isp')
+                    ->label('ISP')
+                    ->toggleable()
+                    ->toggledHiddenByDefault()
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('data->isp', $direction);
                     }),
                 Tables\Columns\TextColumn::make('data.server.name')
                     ->toggleable()

--- a/app/Listeners/Discord/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/Discord/SendSpeedtestCompletedNotification.php
@@ -38,6 +38,7 @@ class SendSpeedtestCompletedNotification
                 'service' => Str::title($event->result->service),
                 'serverName' => $event->result->server_name,
                 'serverId' => $event->result->server_id,
+                'isp' => $event->result->isp,
                 'ping' => round($event->result->ping).' ms',
                 'download' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
                 'upload' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),

--- a/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Discord/SendSpeedtestThresholdNotification.php
@@ -67,6 +67,7 @@ class SendSpeedtestThresholdNotification
                 'service' => Str::title($event->result->service),
                 'serverName' => $event->result->server_name,
                 'serverId' => $event->result->server_id,
+                'isp' => $event->result->isp,
                 'metrics' => $failed,
                 'url' => url('/admin/results'),
             ])->render(),

--- a/app/Listeners/Telegram/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/Telegram/SendSpeedtestCompletedNotification.php
@@ -38,6 +38,7 @@ class SendSpeedtestCompletedNotification
             'service' => Str::title($event->result->service),
             'serverName' => $event->result->server_name,
             'serverId' => $event->result->server_id,
+            'isp' => $event->result->isp,
             'ping' => round($event->result->ping).' ms',
             'download' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
             'upload' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),

--- a/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Telegram/SendSpeedtestThresholdNotification.php
@@ -67,6 +67,7 @@ class SendSpeedtestThresholdNotification
             'service' => Str::title($event->result->service),
             'serverName' => $event->result->server_name,
             'serverId' => $event->result->server_id,
+            'isp' => $event->result->isp,
             'metrics' => $failed,
             'url' => url('/admin/results'),
         ])->render();

--- a/app/Listeners/Webhook/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestCompletedNotification.php
@@ -36,6 +36,7 @@ class SendSpeedtestCompletedNotification
                 ->payload([
                     'result_id' => $event->result->id,
                     'site_name' => config('app.name'),
+                    'isp' => $event->result->isp,
                     'ping' => $event->result->ping,
                     'download' => $event->result->downloadBits,
                     'upload' => $event->result->uploadBits,

--- a/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Webhook/SendSpeedtestThresholdNotification.php
@@ -66,6 +66,7 @@ class SendSpeedtestThresholdNotification
                 ->payload([
                     'result_id' => $event->result->id,
                     'site_name' => config('app.name'),
+                    'isp' => $event->result->isp,
                     'metrics' => $failed,
                     'url' => url('/admin/results'),
                 ])

--- a/app/Mail/SpeedtestCompletedMail.php
+++ b/app/Mail/SpeedtestCompletedMail.php
@@ -48,6 +48,7 @@ class SpeedtestCompletedMail extends Mailable implements ShouldQueue
                 'service' => Str::title($this->result->service),
                 'serverName' => $this->result->server_name,
                 'serverId' => $this->result->server_id,
+                'isp' => $event->result->isp,
                 'ping' => round($this->result->ping, 2).' ms',
                 'download' => Number::toBitRate(bits: $this->result->download_bits, precision: 2),
                 'upload' => Number::toBitRate(bits: $this->result->upload_bits, precision: 2),

--- a/app/Mail/SpeedtestThresholdMail.php
+++ b/app/Mail/SpeedtestThresholdMail.php
@@ -48,6 +48,7 @@ class SpeedtestThresholdMail extends Mailable implements ShouldQueue
                 'service' => Str::title($this->result->service),
                 'serverName' => $this->result->server_name,
                 'serverId' => $this->result->server_id,
+                'isp' => $event->result->isp,
                 'url' => url('/admin/results'),
                 'metrics' => $this->metrics,
             ],

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -69,6 +69,7 @@ class Result extends Model
             'upload_latency_low' => $this->upload_latency_low,
             'upload_latency_high' => $this->upload_latency_high,
             'server_id' => $this?->server_id,
+            'isp' => $this?->isp,
             'server_host' => $this?->server_host,
             'server_name' => $this?->server_name,
             'scheduled' => $this->scheduled,

--- a/resources/views/discord/speedtest-completed.blade.php
+++ b/resources/views/discord/speedtest-completed.blade.php
@@ -4,6 +4,7 @@ A new speedtest was completed using **{{ $service }}**.
 
 - **Server name:** {{ $serverName }}
 - **Server ID:** {{ $serverId }}
+- **ISP:** {{ $isp }}
 - **Ping:** {{ $ping }}
 - **Download:** {{ $download }}
 - **Upload:** {{ $upload }}

--- a/resources/views/discord/speedtest-threshold.blade.php
+++ b/resources/views/discord/speedtest-threshold.blade.php
@@ -1,6 +1,6 @@
 **Speedtest Threshold Breached - #{{ $id }}**
 
-A new speedtest was completed using **{{ $service }}** but a threshold was breached.
+A new speedtest was completed using **{{ $service }}** on **{{ $isp }}** but a threshold was breached.
 
 @foreach ($metrics as $item)
 - **{{ $item['name'] }}** {{ $item['threshold'] }}: {{ $item['value'] }}

--- a/resources/views/emails/speedtest-completed.blade.php
+++ b/resources/views/emails/speedtest-completed.blade.php
@@ -8,6 +8,7 @@ A new speedtest was completed using **{{ $service }}**.
 |:------------|---------------------------:|
 | Server name | {{ $serverName }}          |
 | Server ID   | {{ $serverId }}            |
+| ISP         | {{ $isp }}                 |
 | Ping        | {{ $ping }}                |
 | Download    | {{ $download }}            |
 | Upload      | {{ $upload }}              |

--- a/resources/views/emails/speedtest-threshold.blade.php
+++ b/resources/views/emails/speedtest-threshold.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # Speedtest Threshold Breached - #{{ $id }}
 
-A new speedtest was completed using **{{ $service }}** but a threshold was breached.
+A new speedtest was completed using **{{ $service }}** on **{{ $isp }}** but a threshold was breached.
 
 <x-mail::table>
 | **Metric** | **Threshold** | **Value** |

--- a/resources/views/telegram/speedtest-completed.blade.php
+++ b/resources/views/telegram/speedtest-completed.blade.php
@@ -4,6 +4,7 @@ A new speedtest was completed using *{{ $service }}*.
 
 - *Server name:* {{ $serverName }}
 - *Server ID:* {{ $serverId }}
+- **ISP:** {{ $isp }}
 - *Ping:* {{ $ping }}
 - *Download:* {{ $download }}
 - *Upload:* {{ $upload }}

--- a/resources/views/telegram/speedtest-threshold.blade.php
+++ b/resources/views/telegram/speedtest-threshold.blade.php
@@ -1,8 +1,8 @@
-*Speedtest Threshold Breached - #{{ $id }}*
+**Speedtest Threshold Breached - #{{ $id }}**
 
-A new speedtest was completed using *{{ $service }}* but a threshold was breached.
+A new speedtest was completed using **{{ $service }}** on **{{ $isp }}** but a threshold was breached.
 
 @foreach ($metrics as $item)
-- *{{ $item['name'] }}* {{ $item['threshold'] }}: {{ $item['value'] }}
+- **{{ $item['name'] }}** {{ $item['threshold'] }}: {{ $item['value'] }}
 @endforeach
 - **URL:** {{ $url }}


### PR DESCRIPTION
## 📃 Description

to close https://github.com/alexjustesen/speedtest-tracker/issues/658

## 🪵 Changelog

Add the ISP name value to the results. 

### ➕ Added

- ISP value to:
 - Results table (hiding by default)
 - Results export
 - Notifications
 - InfluxDB

## 📷 Screenshots
<img width="627" alt="Scherm­afbeelding 2024-06-10 om 23 17 26" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/68970bc2-67af-4635-83bf-89125100a25d">

