### PR TITLE
Fix issue with Notify on every speedtest run failing 

### DIFF
--- a/app/Mail/SpeedtestCompletedMail.php
+++ b/app/Mail/SpeedtestCompletedMail.php
@@ -48,7 +48,7 @@ class SpeedtestCompletedMail extends Mailable implements ShouldQueue
                 'service' => Str::title($this->result->service),
                 'serverName' => $this->result->server_name,
                 'serverId' => $this->result->server_id,
-                'isp' => $event->result->isp,
+                'isp' => $this->result->isp,
                 'ping' => round($this->result->ping, 2).' ms',
                 'download' => Number::toBitRate(bits: $this->result->download_bits, precision: 2),
                 'upload' => Number::toBitRate(bits: $this->result->upload_bits, precision: 2),

--- a/app/Mail/SpeedtestThresholdMail.php
+++ b/app/Mail/SpeedtestThresholdMail.php
@@ -48,7 +48,7 @@ class SpeedtestThresholdMail extends Mailable implements ShouldQueue
                 'service' => Str::title($this->result->service),
                 'serverName' => $this->result->server_name,
                 'serverId' => $this->result->server_id,
-                'isp' => $event->result->isp,
+                'isp' => $this->result->isp,
                 'url' => url('/admin/results'),
                 'metrics' => $this->metrics,
             ],


### PR DESCRIPTION
Notify on every speedtest run failing:

[2024-06-11 12:38:08] production.ERROR: Undefined variable $event {"exception":"[object] (ErrorException(code: 0): Undefined variable $event at /app/www/app/Mail/SpeedtestCompletedMail.php:51) [stacktrace]

## 📃 Description

A short description of the pull request changes should go here and the sections below should list in detail all changes. You can remove the sections you don't need.

Fix issue with Notify on every speedtest run failing 

## 🪵 Changelog

### ➕ Added

- one
- two

### ✏️ Changed

- /app/www/app/Mail/SpeedtestCompletedMail.php 
- two

### 🔧 Fixed

- one
- two

### 🗑️ Removed

- one
- two

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.
