### PR TITLE
[Feature] Write the server id to the result on failed tests

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -64,6 +64,7 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
             $message = collect(array_filter($messages, 'json_validate'))->last();
 
             $this->result->update([
+                'server_id' => $this->serverId,
                 'data' => json_decode($message, true),
                 'status' => ResultStatus::Failed,
             ]);
@@ -100,6 +101,7 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
 
         if ($ping->ping() === false) {
             $this->result->update([
+                'server_id' => $this->serverId,
                 'data' => [
                     'type' => 'log',
                     'level' => 'error',


### PR DESCRIPTION
## 📃 Description

If a server ID is present it will now be written to the result record if the test fails. This will help track down missing servers mentioned in #1519.

## 🪵 Changelog

### ➕ Added

- server ID to failed tests
