### PR TITLE
Add Server location to results and export

### DIFF
--- a/app/Filament/Exports/ResultExporter.php
+++ b/app/Filament/Exports/ResultExporter.php
@@ -36,6 +36,12 @@ class ResultExporter extends Exporter
                     return $record->isp;
                 })
                 ->enabledByDefault(false),
+            ExportColumn::make('server_location')
+                ->label('Server Location')
+                ->state(function (Result $record): ?string {
+                    return $record->server_location;
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('service'),
             ExportColumn::make('server_id')
                 ->label('Server ID')

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -102,6 +102,9 @@ class ResultResource extends Resource
                             Forms\Components\Placeholder::make('isp')
                                 ->label('ISP')
                                 ->content(fn (Result $result): ?string => $result->isp),
+                            Forms\Components\Placeholder::make('server_location')
+                                ->label('Server Location')
+                                ->content(fn (Result $result): ?string => $result->server_location),
                             Forms\Components\Placeholder::make('server_host')
                                 ->content(fn (Result $result): ?string => $result->server_host),
                             Forms\Components\Checkbox::make('scheduled'),
@@ -147,6 +150,13 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->isp', $direction);
+                    }),
+                Tables\Columns\TextColumn::make('data.server.location')
+                    ->label('Server Location')
+                    ->toggleable()
+                    ->toggledHiddenByDefault()
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('data->server->location', $direction);
                     }),
                 Tables\Columns\TextColumn::make('data.server.name')
                     ->toggleable()

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -70,7 +70,6 @@ class Result extends Model
             'upload_latency_high' => $this->upload_latency_high,
             'server_id' => $this?->server_id,
             'isp' => $this?->isp,
-            'location' => $this?->location,
             'server_host' => $this?->server_host,
             'server_name' => $this?->server_name,
             'server_location' => $this?->server_location,

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -70,6 +70,7 @@ class Result extends Model
             'upload_latency_high' => $this->upload_latency_high,
             'server_id' => $this?->server_id,
             'isp' => $this?->isp,
+            'location' => $this?->location,
             'server_host' => $this?->server_host,
             'server_name' => $this?->server_name,
             'scheduled' => $this->scheduled,
@@ -227,7 +228,16 @@ class Result extends Model
             get: fn () => Arr::get($this->data, 'server.name'),
         );
     }
-
+    
+     /**
+     * Get the result's server location.
+     */
+    protected function serverLocation(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => Arr::get($this->data, 'server.location'),
+        );
+    }
     /**
      * Get the result's upload in bits.
      */

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -73,6 +73,7 @@ class Result extends Model
             'location' => $this?->location,
             'server_host' => $this?->server_host,
             'server_name' => $this?->server_name,
+            'server_location' => $this?->server_location,
             'scheduled' => $this->scheduled,
             'successful' => $this->status === ResultStatus::Completed,
             'packet_loss' => (float) $this->packet_loss,

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -229,8 +229,8 @@ class Result extends Model
             get: fn () => Arr::get($this->data, 'server.name'),
         );
     }
-    
-     /**
+
+    /**
      * Get the result's server location.
      */
     protected function serverLocation(): Attribute
@@ -239,6 +239,7 @@ class Result extends Model
             get: fn () => Arr::get($this->data, 'server.location'),
         );
     }
+
     /**
      * Get the result's upload in bits.
      */


### PR DESCRIPTION
## 📃 Description

Some ISPs have multiple server across the countries / network. When testing with multiple of these server it can useful to see their location as the Name will be the same. 

## 🪵 Changelog

### ➕ Added

- Add Server location to results and export


