### PR TITLE
Fix value rounding 

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -64,57 +64,57 @@ class ResultResource extends Resource
                             Forms\Components\TextInput::make('ping')
                                 ->label('Ping')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.download.latency.jitter')
                                 ->label('Download Jitter (ms)')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.download.latency.high')
                                 ->label('Download Latency High')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.download.latency.low')
                                 ->label('Download Latency low')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.download.latency.iqm')
                                 ->label('Download Latency iqm')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.upload.latency.jitter')
                                 ->label('Upload Jitter')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.upload.latency.high')
                                 ->label('Upload Latency High')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.upload.latency.low')
                                 ->label('Upload Latency low')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.upload.latency.iqm')
                                 ->label('Upload Latency iqm')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.ping.jitter')
                                 ->label('Ping Jitter')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                    return number_format((float) $state, 0, '.', '').' ms';
                                 }),
                             Forms\Components\TextInput::make('data.packetLoss')
                                 ->label('Packet Loss')
                                 ->formatStateUsing(function ($state) {
-                                    return number_format((float)$state, 2, '.', '') . ' %';
+                                    return number_format((float) $state, 2, '.', '').' %';
                                 }),
                             Forms\Components\Textarea::make('data.message')
                                 ->label('Error Message')
@@ -196,7 +196,7 @@ class ResultResource extends Resource
                     ->toggleable()
                     ->sortable()
                     ->formatStateUsing(function ($state) {
-                    return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.jitter')
                     ->label('Download jitter')
@@ -206,7 +206,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->download->latency->jitter', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.high')
                     ->label('Download latency high')
@@ -216,7 +216,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->download->latency->high', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.low')
                     ->label('Download latency low')
@@ -226,7 +226,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->download->latency->low', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.iqm')
                     ->label('Download latency iqm')
@@ -236,7 +236,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->download->latency->iqm', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.jitter')
                     ->label('Upload jitter')
@@ -246,7 +246,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->upload->latency->jitter', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.high')
                     ->label('Upload latency high')
@@ -256,7 +256,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->upload->latency->high', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.low')
                     ->label('Upload latency low')
@@ -266,7 +266,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->upload->latency->low', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.iqm')
                     ->label('Upload latency iqm')
@@ -276,7 +276,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->upload->latency->iqm', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.ping.jitter')
                     ->label('Ping jitter')
@@ -286,7 +286,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->ping->jitter', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 0, '.', '') . ' ms';
+                        return number_format((float) $state, 0, '.', '').' ms';
                     }),
                 Tables\Columns\TextColumn::make('packet_loss')
                     ->toggleable()
@@ -295,7 +295,7 @@ class ResultResource extends Resource
                         return $query->orderBy('data->packetLoss', $direction);
                     })
                     ->formatStateUsing(function ($state) {
-                        return number_format((float)$state, 2, '.', '') . ' %';
+                        return number_format((float) $state, 2, '.', '').' %';
                     }),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -62,27 +62,60 @@ class ResultResource extends Resource
                                     $component->state(! blank($record->upload) ? Number::toBitRate(bits: $record->upload_bits, precision: 2) : '');
                                 }),
                             Forms\Components\TextInput::make('ping')
-                                ->label('Ping (ms)'),
+                                ->label('Ping')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.download.latency.jitter')
-                                ->label('Download Jitter (ms)'),
+                                ->label('Download Jitter (ms)')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.download.latency.high')
-                                ->label('Download Latency High'),
+                                ->label('Download Latency High')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.download.latency.low')
-                                ->label('Download Latency low'),
+                                ->label('Download Latency low')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.download.latency.iqm')
-                                ->label('Download Latency iqm'),
+                                ->label('Download Latency iqm')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.upload.latency.jitter')
-                                ->label('Upload Jitter (ms)'),
+                                ->label('Upload Jitter')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.upload.latency.high')
-                                ->label('Upload Latency High'),
+                                ->label('Upload Latency High')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.upload.latency.low')
-                                ->label('Upload Latency low'),
+                                ->label('Upload Latency low')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.upload.latency.iqm')
-                                ->label('Upload Latency iqm'),
+                                ->label('Upload Latency iqm')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.ping.jitter')
-                                ->label('Ping Jitter (ms)'),
+                                ->label('Ping Jitter')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 0, '.', '') . ' ms';
+                                }),
                             Forms\Components\TextInput::make('data.packetLoss')
-                                ->label('Packet Loss'),
+                                ->label('Packet Loss')
+                                ->formatStateUsing(function ($state) {
+                                    return number_format((float)$state, 2, '.', '') . ' %';
+                                }),
                             Forms\Components\Textarea::make('data.message')
                                 ->label('Error Message')
                                 ->hint(new HtmlString('&#x1f517;<a href="https://docs.speedtest-tracker.dev/help/error-messages" target="_blank" rel="nofollow">Error Messages</a>'))
@@ -161,13 +194,19 @@ class ResultResource extends Resource
                     ->sortable(),
                 Tables\Columns\TextColumn::make('ping')
                     ->toggleable()
-                    ->sortable(),
+                    ->sortable()
+                    ->formatStateUsing(function ($state) {
+                    return number_format((float)$state, 0, '.', '') . ' ms';
+                    }),
                 Tables\Columns\TextColumn::make('data.download.latency.jitter')
                     ->label('Download jitter')
                     ->toggleable()
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->download->latency->jitter', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.high')
                     ->label('Download latency high')
@@ -175,6 +214,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->download->latency->high', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.low')
                     ->label('Download latency low')
@@ -182,6 +224,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->download->latency->low', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.download.latency.iqm')
                     ->label('Download latency iqm')
@@ -189,6 +234,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->download->latency->iqm', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.jitter')
                     ->label('Upload jitter')
@@ -196,6 +244,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->upload->latency->jitter', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.high')
                     ->label('Upload latency high')
@@ -203,6 +254,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->upload->latency->high', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.low')
                     ->label('Upload latency low')
@@ -210,6 +264,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->upload->latency->low', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.upload.latency.iqm')
                     ->label('Upload latency iqm')
@@ -217,6 +274,9 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->upload->latency->iqm', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('data.ping.jitter')
                     ->label('Ping jitter')
@@ -224,10 +284,19 @@ class ResultResource extends Resource
                     ->toggledHiddenByDefault()
                     ->sortable(query: function (Builder $query, string $direction): Builder {
                         return $query->orderBy('data->ping->jitter', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 0, '.', '') . ' ms';
                     }),
                 Tables\Columns\TextColumn::make('packet_loss')
                     ->toggleable()
-                    ->toggledHiddenByDefault(),
+                    ->toggledHiddenByDefault()
+                    ->sortable(query: function (Builder $query, string $direction): Builder {
+                        return $query->orderBy('data->packetLoss', $direction);
+                    })
+                    ->formatStateUsing(function ($state) {
+                        return number_format((float)$state, 2, '.', '') . ' %';
+                    }),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->toggleable()


### PR DESCRIPTION
## 📃 Description

To close https://github.com/alexjustesen/speedtest-tracker/issues/1545

## 🪵 Changelog

In the results tables and pop up view:
- Round up the Packet loss with 2 and add a `%`
- Round up the Upload and Download latency  with 0 and add `ms`
- Round up the Ping  with 0 and add `ms`

## 📷 Screenshots

**Before:** 

<img width="1257" alt="Scherm­afbeelding 2024-06-19 om 17 22 58" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/cd9d122d-458b-47fa-9dc6-b37e1330e8e4">

<img width="840" alt="Scherm­afbeelding 2024-06-19 om 17 23 04" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/eb5063f5-75f4-4fab-ac8f-b6884370adbd">

**After**

<img width="1241" alt="Scherm­afbeelding 2024-06-19 om 18 05 46" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/bdfa0a97-f1b2-4cac-92b6-e1d0420aa496">
<img width="926" alt="Scherm­afbeelding 2024-06-19 om 18 06 32" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/b2e692e7-24ab-4fca-a9de-7a896e56d8ff">

