### PR TITLE
Add Placeholder text for notifications

### DIFF
--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -108,6 +108,7 @@ class NotificationPage extends SettingsPage
                                                     ->label('Webhooks')
                                                     ->schema([
                                                         Forms\Components\TextInput::make('url')
+                                                            ->placeholder('https://discord.com/api/webhooks/longstringofcharacters')
                                                             ->maxLength(2000)
                                                             ->required()
                                                             ->url(),
@@ -151,6 +152,7 @@ class NotificationPage extends SettingsPage
                                                     ->label('Recipients')
                                                     ->schema([
                                                         Forms\Components\TextInput::make('email_address')
+                                                            ->placeholder('your@email.com')
                                                             ->email()
                                                             ->required(),
                                                     ])
@@ -199,6 +201,7 @@ class NotificationPage extends SettingsPage
                                                     ->label('Recipients')
                                                     ->schema([
                                                         Forms\Components\TextInput::make('telegram_chat_id')
+                                                            ->placeholder('12345678910')
                                                             ->label('Telegram Chat ID')
                                                             ->maxLength(50)
                                                             ->required(),
@@ -242,6 +245,7 @@ class NotificationPage extends SettingsPage
                                                     ->label('Recipients')
                                                     ->schema([
                                                         Forms\Components\TextInput::make('url')
+                                                            ->placeholder('https://webhook.site/longstringofcharacters')
                                                             ->maxLength(2000)
                                                             ->required()
                                                             ->url(),


### PR DESCRIPTION
## 📃 Description

This PR adds a placeholder text for the notification endpoint. To five the user an idea what the giving url/id should look like. 
