### PR TITLE
Add Pushover Notifications via Webhooks

### DIFF
--- a/app/Actions/Notifications/SendPushoverTestNotification.php
+++ b/app/Actions/Notifications/SendPushoverTestNotification.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions\Notifications;
+
+use Filament\Notifications\Notification;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendPushoverTestNotification
+{
+    use AsAction;
+
+    public function handle(array $webhooks)
+    {
+        if (! count($webhooks)) {
+            Notification::make()
+                ->title('You need to add Pushover URLs!')
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        foreach ($webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload([
+                    'token' => $webhook['api_token'],
+                    'user' => $webhook['user_key'],
+                    'message' => '👋 Testing the Pushover notification channel.',
+                ])
+                ->doNotSign()
+                ->dispatch();
+        }
+
+        Notification::make()
+            ->title('Test Pushover notification sent.')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -5,6 +5,7 @@ namespace App\Filament\Pages\Settings;
 use App\Actions\Notifications\SendDatabaseTestNotification;
 use App\Actions\Notifications\SendDiscordTestNotification;
 use App\Actions\Notifications\SendMailTestNotification;
+use App\Actions\Notifications\SendPushoverTestNotification;
 use App\Actions\Notifications\SendTelegramTestNotification;
 use App\Actions\Notifications\SendWebhookTestNotification;
 use App\Settings\NotificationSettings;
@@ -75,6 +76,60 @@ class NotificationPage extends SettingsPage
                                                     Forms\Components\Actions\Action::make('test database')
                                                         ->label('Test database channel')
                                                         ->action(fn () => SendDatabaseTestNotification::run(user: Auth::user())),
+                                                ]),
+                                            ]),
+                                    ])
+                                    ->compact()
+                                    ->columns([
+                                        'default' => 1,
+                                        'md' => 2,
+                                    ]),
+
+                                Forms\Components\Section::make('Pushover')
+                                    ->schema([
+                                        Forms\Components\Toggle::make('pushover_enabled')
+                                            ->label('Enable Pushover webhook notifications')
+                                            ->reactive()
+                                            ->columnSpanFull(),
+                                        Forms\Components\Grid::make([
+                                            'default' => 1,
+                                        ])
+                                            ->hidden(fn (Forms\Get $get) => $get('pushover_enabled') !== true)
+                                            ->schema([
+                                                Forms\Components\Fieldset::make('Triggers')
+                                                    ->schema([
+                                                        Forms\Components\Toggle::make('pushover_on_speedtest_run')
+                                                            ->label('Notify on every speedtest run')
+                                                            ->columnSpanFull(),
+                                                        Forms\Components\Toggle::make('pushover_on_threshold_failure')
+                                                            ->label('Notify on threshold failures')
+                                                            ->columnSpanFull(),
+                                                    ]),
+                                                Forms\Components\Repeater::make('pushover_webhooks')
+                                                    ->label('Pushover Webhooks')
+                                                    ->schema([
+                                                        Forms\Components\TextInput::make('url')
+                                                            ->label('URL')
+                                                            ->maxLength(2000)
+                                                            ->required()
+                                                            ->url(),
+                                                        Forms\Components\TextInput::make('user_key')
+                                                            ->label('User Key')
+                                                            ->maxLength(200)
+                                                            ->required(),
+                                                        Forms\Components\TextInput::make('api_token')
+                                                            ->label('API Token')
+                                                            ->maxLength(200)
+                                                            ->required(),
+                                                    ])
+                                                    ->columnSpanFull(),
+                                                Forms\Components\Actions::make([
+                                                    Forms\Components\Actions\Action::make('test pushover')
+                                                        ->label('Test Pushover webhook')
+                                                        ->action(fn (Forms\Get $get) => SendPushoverTestNotification::run(
+                                                            webhooks: $get('pushover_webhooks')
+                                                        ))
+                                                        ->hidden(fn (Forms\Get $get) => ! count($get('pushover_webhooks'))),
                                                 ]),
                                             ]),
                                     ])

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -110,15 +110,18 @@ class NotificationPage extends SettingsPage
                                                     ->schema([
                                                         Forms\Components\TextInput::make('url')
                                                             ->label('URL')
+                                                            ->placeholder('http://api.pushover.net/1/messages.json')
                                                             ->maxLength(2000)
                                                             ->required()
                                                             ->url(),
                                                         Forms\Components\TextInput::make('user_key')
                                                             ->label('User Key')
+                                                            ->placeholder('Your Pushover User Key')
                                                             ->maxLength(200)
                                                             ->required(),
                                                         Forms\Components\TextInput::make('api_token')
                                                             ->label('API Token')
+                                                            ->placeholder('Your Pushover API Token')
                                                             ->maxLength(200)
                                                             ->required(),
                                                     ])

--- a/app/Listeners/Pushover/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/Pushover/SendSpeedtestCompletedNotification.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Listeners\Pushover;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestCompletedNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings();
+
+        if (! $notificationSettings->pushover_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->pushover_on_speedtest_run) {
+            return;
+        }
+
+        if (! count($notificationSettings->pushover_webhooks)) {
+            Log::warning('Pushover urls not found, check Pushover notification channel settings.');
+
+            return;
+        }
+
+        $payload = [
+            view('pushover.speedtest-completed', [
+                'id' => $event->result->id,
+                'service' => Str::title($event->result->service),
+                'serverName' => $event->result->server_name,
+                'serverId' => $event->result->server_id,
+                'isp' => $event->result->isp,
+                'ping' => round($event->result->ping).' ms',
+                'download' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+                'upload' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+                'packetLoss' => $event->result->packet_loss,
+                'url' => url('/admin/results'),
+            ])->render(),
+        ];
+
+        foreach ($notificationSettings->pushover_webhooks as $url) {
+            WebhookCall::create()
+                ->url($url['url'])
+                ->payload([
+                    'token' => $url['api_token'],
+                    'user' => $url['user_key'],
+                    'message' => $payload,
+                ])
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+}

--- a/app/Listeners/Pushover/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/Pushover/SendSpeedtestThresholdNotification.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Listeners\Pushover;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use App\Settings\ThresholdSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestThresholdNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings();
+
+        if (! $notificationSettings->pushover_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->pushover_on_threshold_failure) {
+            return;
+        }
+
+        if (! count($notificationSettings->pushover_webhooks)) {
+            Log::warning('Pushover urls not found, check Pushover notification channel settings.');
+
+            return;
+        }
+
+        $thresholdSettings = new ThresholdSettings();
+
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
+        $failed = [];
+
+        if ($thresholdSettings->absolute_download > 0) {
+            array_push($failed, $this->absoluteDownloadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_upload > 0) {
+            array_push($failed, $this->absoluteUploadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_ping > 0) {
+            array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        $failed = array_filter($failed);
+
+        if (! count($failed)) {
+            Log::warning('Failed Pushover thresholds not found, won\'t send notification.');
+
+            return;
+        }
+
+        $payload = [
+            view('pushover.speedtest-threshold', [
+                'id' => $event->result->id,
+                'service' => Str::title($event->result->service),
+                'serverName' => $event->result->server_name,
+                'serverId' => $event->result->server_id,
+                'isp' => $event->result->isp,
+                'metrics' => $failed,
+                'url' => url('/admin/results'),
+            ])->render(),
+        ];
+
+        foreach ($notificationSettings->pushover_webhooks as $url) {
+            WebhookCall::create()
+                ->url($url['url'])
+                ->payload([
+                    'token' => $url['api_token'],
+                    'user' => $url['user_key'],
+                    'message' => $payload,
+                ])
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+
+    /**
+     * Build Pushover notification if absolute download threshold is breached.
+     */
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Download',
+            'threshold' => $thresholdSettings->absolute_download.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build Pushover notification if absolute upload threshold is breached.
+     */
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Upload',
+            'threshold' => $thresholdSettings->absolute_upload.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build Pushover notification if absolute ping threshold is breached.
+     */
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Ping',
+            'threshold' => $thresholdSettings->absolute_ping.' ms',
+            'value' => round($event->result->ping, 2).' ms',
+        ];
+    }
+}

--- a/app/Settings/NotificationSettings.php
+++ b/app/Settings/NotificationSettings.php
@@ -46,6 +46,14 @@ class NotificationSettings extends Settings
 
     public ?array $discord_webhooks;
 
+    public bool $pushover_enabled;
+
+    public bool $pushover_on_speedtest_run;
+
+    public bool $pushover_on_threshold_failure;
+
+    public ?array $pushover_webhooks;
+
     public static function group(): string
     {
         return 'notification';

--- a/app/Settings/NotificationSettings.php
+++ b/app/Settings/NotificationSettings.php
@@ -53,7 +53,7 @@ class NotificationSettings extends Settings
     public bool $pushover_on_threshold_failure;
 
     public ?array $pushover_webhooks;
-  
+
     public bool $slack_enabled;
 
     public bool $slack_on_speedtest_run;

--- a/database/settings/2024_02_22_144680_create_pushover_notification_settings.php
+++ b/database/settings/2024_02_22_144680_create_pushover_notification_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('notification.pushover_enabled', false);
+        $this->migrator->add('notification.pushover_on_speedtest_run', false);
+        $this->migrator->add('notification.pushover_on_threshold_failure', false);
+        $this->migrator->add('notification.pushover_webhooks', null);
+    }
+};

--- a/resources/views/pushover/speedtest-completed.blade.php
+++ b/resources/views/pushover/speedtest-completed.blade.php
@@ -1,0 +1,12 @@
+Speedtest Completed - #{{ $id }}
+
+A new speedtest was completed using {{ $service }}.
+
+- Server name: {{ $serverName }}
+- Server ID: {{ $serverId }}
+- ISP: {{ $isp }}
+- Ping: {{ $ping }}
+- Download: {{ $download }}
+- Upload: {{ $upload }}
+- Packet Loss: {{ $packetLoss }} %
+- URL: {{ $url }}

--- a/resources/views/pushover/speedtest-threshold.blade.php
+++ b/resources/views/pushover/speedtest-threshold.blade.php
@@ -1,0 +1,8 @@
+Speedtest Threshold Breached - #{{ $id }}
+
+A new speedtest was completed using {{ $service }} on {{ $isp }} but a threshold was breached.
+
+@foreach ($metrics as $item)
+- {{ $item['name'] }} {{ $item['threshold'] }}: {{ $item['value'] }}
+@endforeach
+- URL: {{ $url }}


### PR DESCRIPTION
## 📃 Description

To cross Pushover of the list https://github.com/alexjustesen/speedtest-tracker/issues/40 

## 🪵 Changelog

### ➕ Added

- Add Pushover to the notification page
- Add helperText to the User Key, API Token and url
- Add Pushover to the settings migration
- Add User Key and API Token to the input field


## 📷 Screenshots

Settings; 
<img width="805" alt="Scherm­afbeelding 2024-06-25 om 23 50 58" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/3d15c0ff-91e7-4b53-9d5d-809a6b411419">


Pushover: 
<img width="1350" alt="Scherm­afbeelding 2024-06-25 om 23 44 42" src="https://github.com/alexjustesen/speedtest-tracker/assets/4511676/38d2a4bf-6363-4f77-b5c1-8eab29da940f">

