### PR TITLE
[Bug] Default server id to null when executing speedtest

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -33,7 +33,7 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
      */
     public function __construct(
         public Result $result,
-        public ?int $serverId,
+        public ?int $serverId = null,
     ) {}
 
     /**


### PR DESCRIPTION
## 📃 Description

- closes #1613 

## 🪵 Changelog

### 🔧 Fixed

- default `serverId` to null when executing a speedtest if it fails
