### PR TITLE
[Bug] Don't cache settings by default

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -53,7 +53,7 @@ return [
      * additional prefix.
      */
     'cache' => [
-        'enabled' => env('SETTINGS_CACHE_ENABLED', true),
+        'enabled' => env('SETTINGS_CACHE_ENABLED', false),
         'store' => env('CACHE_STORE', 'database'),
         'prefix' => null,
         'ttl' => null,


### PR DESCRIPTION
## 📃 Description

Don't cache settings by default, this was causing issues when writing new settings to the database.

## 🪵 Changelog

### 🔧 Fixed

- closes #1652 
