### PR TITLE
[Bug] Fix the mail notifications not being sent 

### DIFF
--- a/resources/views/emails/speedtest-completed.blade.php
+++ b/resources/views/emails/speedtest-completed.blade.php
@@ -21,7 +21,7 @@ A new speedtest was completed using **{{ $service }}**.
 View Results
 </x-mail::button>
 
-<x-mail::button :Ookla Speedtest="$speedtest_url">
+<x-mail::button :url="$speedtest_url">
 View Results on Ookla
 </x-mail::button>
 

--- a/resources/views/emails/speedtest-threshold.blade.php
+++ b/resources/views/emails/speedtest-threshold.blade.php
@@ -15,7 +15,7 @@ A new speedtest was completed using **{{ $service }}** on **{{ $isp }}** but a t
 View Results
 </x-mail::button>
 
-<x-mail::button :Ookla Speedtest="$speedtest_url">
+<x-mail::button :url="$speedtest_url">
 View Results on Ookla
 </x-mail::button>
 


### PR DESCRIPTION
## 📃 Description

Due to a oversight by me the mail notifications did not work anymore after adding the Ooka URL  in it.
Closes https://github.com/alexjustesen/speedtest-tracker/issues/1656

Tests:
![image](https://github.com/user-attachments/assets/00dce420-5bdb-45ba-8a4d-c820898ee7b3)

![image](https://github.com/user-attachments/assets/7d083f89-f89d-4494-b341-f1e4448439e9)

![image](https://github.com/user-attachments/assets/e8511d79-71dd-45ab-9a7b-5a9487a86e33)


### 🔧 Fixed

- Fix the mail notifications for Completed tests
- Fix the mail notifications for threshold breaches

(Promise to keep my next contributions to charting improvments, less chance to break things 😉)