### PR TITLE
[Feature] Add Threshold reporting on Results screen

### DIFF
--- a/app/Enums/ThresholdBreached.php
+++ b/app/Enums/ThresholdBreached.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasLabel;
+
+enum ThresholdBreached: string implements HasColor, HasLabel
+{
+    case Failed = 'Failed';
+    case Passed = 'Passed';
+    case Unknown = 'Unknown';
+
+    public function getColor(): ?string
+    {
+        return match ($this) {
+            self::Failed => 'danger',
+            self::Passed => 'success',
+            self::Unknown => 'warning',
+        };
+    }
+
+    public function getLabel(): ?string
+    {
+        return match ($this) {
+            self::Failed => 'Failed',
+            self::Passed => 'Passed',
+            self::Unknown => 'Unknown',
+        };
+    }
+}

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -367,6 +367,10 @@ class ResultResource extends Resource
                 Tables\Filters\SelectFilter::make('status')
                     ->multiple()
                     ->options(ResultStatus::class),
+                Tables\Filters\SelectFilter::make('threshold_breached')
+                    ->label('Threshold Status')
+                    ->multiple()
+                    ->options(ThresholdBreached::class),
             ])
             ->actions([
                 Tables\Actions\ActionGroup::make([

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Actions\MigrateBadJsonResults;
 use App\Enums\ResultStatus;
+use App\Enums\ThresholdBreached;
 use App\Filament\Exports\ResultExporter;
 use App\Filament\Resources\ResultResource\Pages;
 use App\Helpers\Number;
@@ -310,6 +311,13 @@ class ResultResource extends Resource
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->toggleable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('threshold_breached')
+                    ->label('Threshold')
+                    ->badge()
+                    ->color(fn (string $state): string => ThresholdBreached::from($state)->getColor())
+                    ->toggleable()
+                    ->toggledHiddenByDefault()
                     ->sortable(),
                 Tables\Columns\IconColumn::make('scheduled')
                     ->boolean()

--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -83,6 +83,9 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
             'status' => ResultStatus::Completed,
         ]);
 
+        // Ensure thresholds are checked and updated
+        $this->result->checkAndUpdateThresholds();
+
         SpeedtestCompleted::dispatch($this->result);
     }
 

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Enums\ResultStatus;
+use App\Helpers\Number;
+use App\Settings\ThresholdSettings;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -13,6 +15,15 @@ use Illuminate\Support\Arr;
 class Result extends Model
 {
     use HasFactory, Prunable;
+
+    protected $fillable = [
+        'status',
+        'download',
+        'upload',
+        'ping',
+        'data',
+        'threshold_breached',
+    ];
 
     /**
      * The attributes that aren't mass assignable.
@@ -289,5 +300,24 @@ class Result extends Model
         return Attribute::make(
             get: fn () => Arr::get($this->data, 'upload.latency.iqm'),
         );
+    }
+
+    public function checkAndUpdateThresholds(): void
+    {
+
+        $thresholds = app(ThresholdSettings::class);
+
+        // Check if the threshold is breached
+        $downloadInMbits = ! is_null($this->download) ? Number::bitsToMagnitude($this->download_bits, 2, 'mbit') : null;
+        $uploadInMbits = ! is_null($this->upload) ? Number::bitsToMagnitude($this->upload_bits, 2, 'mbit') : null;
+
+        $downloadBreached = $downloadInMbits !== null && $downloadInMbits < $thresholds->absolute_download;
+        $uploadBreached = $uploadInMbits !== null && $uploadInMbits < $thresholds->absolute_upload;
+        $pingBreached = $this->ping !== null && $this->ping > $thresholds->absolute_ping;
+
+        // Update only the threshold_breached field
+        $this->update([
+            'threshold_breached' => $downloadBreached || $uploadBreached || $pingBreached ? 'Failed' : 'Passed',
+        ]);
     }
 }

--- a/database/migrations/2024_08_19_115130_add_threshold_breached_to_results_table.php
+++ b/database/migrations/2024_08_19_115130_add_threshold_breached_to_results_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('results', function (Blueprint $table) {
+            if (! Schema::hasColumn('results', 'threshold_breached')) {
+                $table->enum('threshold_breached', ['Passed', 'Failed', 'Unknown'])->default('Unknown');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('results', function (Blueprint $table) {
+            if (Schema::hasColumn('results', 'threshold_breached')) {
+                $table->dropColumn('threshold_breached');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## 📃 Description

This PR adds the threshold reporting in the Resutls screen. 

To close: https://github.com/alexjustesen/speedtest-tracker/issues/964
To close: https://github.com/alexjustesen/speedtest-tracker/issues/646

## 🪵 Changelog

### ➕ Added

- [x] Add database colunm to store results of the thresholds breach.
        - In order to re-use the status in the future. 
        - In order to not having to check the status on every page loading.
        - Not update the status of other results when the thresholds value is changed.
- [x] Calculate if the thresholds is breached at the end of the speedtests
- [x] Show Passed, Failed and Unknown in the results table
- [x] Add the thresholds status in the filters

### ✏️ Todo

- [ ] Fix the Results export as its now broken. @alexjustesen some tips on this would be appreciated ;) 
- [ ] Set status to "Unknown" for when there is no thresholds defined.
- [ ] Add "Unknown"  as default value to for old results

## 📷 Screenshots

![image](https://github.com/user-attachments/assets/b31c58bb-a4c0-41bd-9d6f-38ceac1c05ea)

![image](https://github.com/user-attachments/assets/801aefa5-a4c7-49f4-bfe5-ab18a390c95d)
