### PR TITLE
Hotfix v0.21.4

### DIFF
--- a/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
+++ b/app/Jobs/Speedtests/ExecuteOoklaSpeedtest.php
@@ -117,6 +117,9 @@ class ExecuteOoklaSpeedtest implements ShouldBeUnique, ShouldQueue
     {
         $url = config('speedtest.ping_url');
 
+        // TODO: skip checking for internet connection, current validation does not take into account different host formats and ip addresses.
+        return true;
+
         // Skip checking for internet connection if ping url isn't set (disabled)
         if (blank($url)) {
             return true;

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -6,7 +6,7 @@ return [
 
     'build_date' => Carbon::parse('2024-10-09'),
 
-    'build_version' => 'v0.21.3',
+    'build_version' => 'v0.21.4',
 
     /**
      * General settings.


### PR DESCRIPTION
## 📃 Description

This PR disables checking for an internet connection before running a speedtest, this regression will be fixed in an upcoming release.

- ref: #1754 