### PR TITLE
[Feature] Added result checking and running statuses

### DIFF
--- a/app/Enums/ResultStatus.php
+++ b/app/Enums/ResultStatus.php
@@ -8,16 +8,20 @@ use Illuminate\Support\Str;
 
 enum ResultStatus: string implements HasColor, HasLabel
 {
+    case Checking = 'checking';
     case Completed = 'completed';
     case Failed = 'failed';
+    case Running = 'running';
     case Started = 'started';
     case Skipped = 'skipped';
 
     public function getColor(): ?string
     {
         return match ($this) {
+            self::Checking => 'info',
             self::Completed => 'success',
             self::Failed => 'danger',
+            self::Running => 'info',
             self::Started => 'info',
             self::Skipped => 'gray',
         };

--- a/app/Events/SpeedtestChecking.php
+++ b/app/Events/SpeedtestChecking.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestChecking
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Events/SpeedtestRunning.php
+++ b/app/Events/SpeedtestRunning.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestRunning
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Actions\GetExternalIpAddress;
 use App\Enums\ResultStatus;
+use App\Events\SpeedtestChecking;
 use App\Events\SpeedtestFailed;
 use App\Models\Result;
 use Illuminate\Bus\Batchable;
@@ -29,6 +30,12 @@ class CheckForInternetConnectionJob implements ShouldQueue
         if ($this->batch()->cancelled()) {
             return;
         }
+
+        $this->result->update([
+            'status' => ResultStatus::Checking,
+        ]);
+
+        SpeedtestChecking::dispatch($this->result);
 
         if (GetExternalIpAddress::run() !== false) {
             return;

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs\Ookla;
 use App\Enums\ResultStatus;
 use App\Events\SpeedtestCompleted;
 use App\Events\SpeedtestFailed;
+use App\Events\SpeedtestRunning;
 use App\Helpers\Ookla;
 use App\Models\Result;
 use Illuminate\Bus\Batchable;
@@ -40,6 +41,12 @@ class RunSpeedtestJob implements ShouldQueue
         if ($this->batch()->cancelled()) {
             return;
         }
+
+        $this->result->update([
+            'status' => ResultStatus::Running,
+        ]);
+
+        SpeedtestRunning::dispatch($this->result);
 
         $command = array_filter([
             'speedtest',


### PR DESCRIPTION
## 📃 Description

This PR adds additional status states to track the progress of the process lifecycle.

## 🪵 Changelog

### ➕ Added

- `Checking` result status, for when a test has been picked up by a worker and is evaluating if it can/should run the test.
- `Running` result status, for when the Speedtest CLI is running and is awaiting results.
