### PR TITLE
[Feature] Added benchmarks to results table

### DIFF
--- a/app/Enums/ResultStatus.php
+++ b/app/Enums/ResultStatus.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 
 enum ResultStatus: string implements HasColor, HasLabel
 {
+    case Benchmarking = 'benchmarking';
     case Checking = 'checking';
     case Completed = 'completed';
     case Failed = 'failed';
@@ -18,6 +19,7 @@ enum ResultStatus: string implements HasColor, HasLabel
     public function getColor(): ?string
     {
         return match ($this) {
+            self::Benchmarking => 'info',
             self::Checking => 'info',
             self::Completed => 'success',
             self::Failed => 'danger',

--- a/app/Events/SpeedtestBenchmarking.php
+++ b/app/Events/SpeedtestBenchmarking.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestBenchmarking
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
+++ b/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Jobs\Ookla;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestBenchmarking;
+use App\Models\Result;
+use App\Settings\ThresholdSettings;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Arr;
+
+class BenchmarkSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        if ($this->batch()->cancelled()) {
+            return;
+        }
+
+        $settings = app(ThresholdSettings::class);
+
+        if ($settings->absolute_enabled === false) {
+            return;
+        }
+
+        $this->result->update([
+            'status' => ResultStatus::Benchmarking,
+        ]);
+
+        SpeedtestBenchmarking::dispatch($this->result);
+
+        $benchmarks = $this->buildBenchmarks($settings);
+
+        if (count($benchmarks) > 0) {
+            $this->result->update([
+                'benchmarks' => $benchmarks,
+            ]);
+        } else {
+            return;
+        }
+    }
+
+    private function buildBenchmarks(ThresholdSettings $settings): array
+    {
+        $benchmarks = [];
+
+        if (! blank($settings->absolute_download) && $settings->absolute_download > 0) {
+            $benchmarks = Arr::add($benchmarks, 'download', [
+                'bar' => 'min',
+                'type' => 'absolute',
+                'value' => $settings->absolute_download,
+                'unit' => 'mbps',
+            ]);
+        }
+
+        if (! blank($settings->absolute_upload) && $settings->absolute_upload > 0) {
+            $benchmarks = Arr::add($benchmarks, 'upload', [
+                'bar' => 'min',
+                'type' => 'absolute',
+                'value' => $settings->absolute_upload,
+                'unit' => 'mbps',
+            ]);
+        }
+
+        if (! blank($settings->absolute_ping) && $settings->absolute_ping > 0) {
+            $benchmarks = Arr::add($benchmarks, 'ping', [
+                'bar' => 'max',
+                'type' => 'absolute',
+                'value' => $settings->absolute_ping,
+                'unit' => 'ms',
+            ]);
+        }
+
+        return $benchmarks;
+    }
+}

--- a/app/Jobs/Ookla/CompleteSpeedtestJob.php
+++ b/app/Jobs/Ookla/CompleteSpeedtestJob.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Jobs\Ookla;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestCompleted;
+use App\Models\Result;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CompleteSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->result->update([
+            'status' => ResultStatus::Completed,
+        ]);
+
+        SpeedtestCompleted::dispatch($this->result);
+    }
+}

--- a/app/Jobs/Ookla/ProcessSpeedtestBatch.php
+++ b/app/Jobs/Ookla/ProcessSpeedtestBatch.php
@@ -33,6 +33,8 @@ class ProcessSpeedtestBatch implements ShouldQueue
                 new CheckForInternetConnectionJob($this->result),
                 new SkipSpeedtestJob($this->result),
                 new RunSpeedtestJob($this->result),
+                new BenchmarkSpeedtestJob($this->result),
+                new CompleteSpeedtestJob($this->result),
             ],
         ])->catch(function (Batch $batch, ?Throwable $e) {
             Log::error(sprintf('Speedtest batch "%s" failed for an unknown reason.', $batch->id));

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -3,7 +3,6 @@
 namespace App\Jobs\Ookla;
 
 use App\Enums\ResultStatus;
-use App\Events\SpeedtestCompleted;
 use App\Events\SpeedtestFailed;
 use App\Events\SpeedtestRunning;
 use App\Helpers\Ookla;
@@ -68,6 +67,8 @@ class RunSpeedtestJob implements ShouldQueue
                 'status' => ResultStatus::Failed,
             ]);
 
+            $this->batch()->cancel();
+
             SpeedtestFailed::dispatch($this->result);
 
             return;
@@ -80,9 +81,6 @@ class RunSpeedtestJob implements ShouldQueue
             'download' => Arr::get($output, 'download.bandwidth'),
             'upload' => Arr::get($output, 'upload.bandwidth'),
             'data' => $output,
-            'status' => ResultStatus::Completed,
         ]);
-
-        SpeedtestCompleted::dispatch($this->result);
     }
 }

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -30,6 +30,7 @@ class Result extends Model
     protected function casts(): array
     {
         return [
+            'benchmarks' => 'array',
             'data' => 'array',
             'service' => ResultService::class,
             'status' => ResultStatus::class,

--- a/database/migrations/2024_11_22_235011_add_benchmarks_to_results_table.php
+++ b/database/migrations/2024_11_22_235011_add_benchmarks_to_results_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('results', function (Blueprint $table) {
+            $table->json('benchmarks')
+                ->nullable()
+                ->after('data');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
## 📃 Description

This PR adds any active benchmarks (aka thresholds) at the time of testing to the result record in the database.

## 🪵 Changelog

### ➕ Added

- `Benchmarking` result status.
- `CompletedSpeedtestJob` to clearly define the end of the speedtest batch process.

### ✏️ Changed

- Don't complete a test until the last job has finished processing.
