### PR TITLE
[Bug] Fix Skipped Tests not marked as skipped

### DIFF
--- a/app/Jobs/Ookla/CompleteSpeedtestJob.php
+++ b/app/Jobs/Ookla/CompleteSpeedtestJob.php
@@ -25,6 +25,10 @@ class CompleteSpeedtestJob implements ShouldQueue
      */
     public function handle(): void
     {
+        if ($this->batch()->cancelled()) {
+            return;
+        }
+
         $this->result->update([
             'status' => ResultStatus::Completed,
         ]);

--- a/app/Jobs/SkipSpeedtestJob.php
+++ b/app/Jobs/SkipSpeedtestJob.php
@@ -52,7 +52,7 @@ class SkipSpeedtestJob implements ShouldQueue
             'data->type' => 'log',
             'data->level' => 'error',
             'data->message' => $shouldSkip,
-            'interface->externalIp' => $externalIp,
+            'data->interface->externalIp' => $externalIp,
             'status' => ResultStatus::Skipped,
         ]);
 


### PR DESCRIPTION
## 📃 Description

This PR fixes writing the skipped tests are not marked as skipped

## 🪵 Changelog

### 🔧 Fixed

- Set the correct db schema for saving the IP  `'data->interface->externalIp' ` instead of `interface->externalIp' => $externalIp`
- CompletedSpeedtestJob ignored cancelled jobs which got them marks as completed instead of skipped
