### PR TITLE
[Bug] Capture curl errors when offline

### DIFF
--- a/app/Filament/Pages/Dashboard.php
+++ b/app/Filament/Pages/Dashboard.php
@@ -57,7 +57,6 @@ class Dashboard extends BasePage
                     Forms\Components\Select::make('server_id')
                         ->label('Select Server')
                         ->helperText('Leave empty to run the speedtest without specifying a server.')
-                        ->options(fn (): array => GetOoklaSpeedtestServers::run())
                         ->options(function (): array {
                             return array_filter([
                                 'Manual servers' => Ookla::getConfigServers(),


### PR DESCRIPTION
## 📃 Description

This PR fixes capturing curl errors when calling a URL especially when offline. 

- closes #1821 
- closes #1824 

## 🪵 Changelog

### ➕ Added

- note to docs (https://docs.speedtest-tracker.dev/help/faqs#adguard-and-pi-hole-allow-domains) that `https://icanhazip.com/` needs to be added to your allow lists in AdGuard and Pi-hole.

### 🔧 Fixed

- correctly capture errors when attempting to curl a URL for results.
