### PR TITLE
[Feature] Add Average for Download, Upload, Ping

### DIFF
--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
@@ -52,13 +53,23 @@ class RecentDownloadChartWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Download',
-                    'data' => $results->map(fn ($item) => ! blank($item->download) ? Number::bitsToMagnitude(bits: $item->download_bits, precision: 2, magnitude: 'mbit') : 0),
-                    'borderColor' => '#0ea5e9',
-                    'backgroundColor' => '#0ea5e9',
-                    'pointBackgroundColor' => '#0ea5e9',
+                    'data' => $results->map(fn ($item) => ! blank($item->download) ? Number::bitsToMagnitude(bits: $item->download_bits, precision: 2, magnitude: 'mbit') : null),
+                    'borderColor' => 'rgba(14, 165, 233)',
+                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
+                    'cubicInterpolationMode' => 'monotone',
+                    'tension' => 0.4,
+                ],
+                [
+                    'label' => 'Average',
+                    'data' => array_fill(0, count($results), Average::averageDownload($results)),
+                    'borderColor' => 'rgb(243, 7, 6, 1)',
+                    'pointBackgroundColor' => 'rgb(243, 7, 6, 1)',
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
+                    'borderDash' => [5, 5],
+                    'pointRadius' => 0,
                 ],
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
@@ -70,7 +81,13 @@ class RecentDownloadChartWidget extends ChartWidget
         return [
             'plugins' => [
                 'legend' => [
-                    'display' => false,
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
                 ],
             ],
             'scales' => [

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -51,31 +51,28 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Average (ms)',
-                    'data' => $results->map(fn ($item) => $item->download_latency_iqm ? number_format($item->download_latency_iqm, 2) : 0),
-                    'borderColor' => '#10b981',
-                    'backgroundColor' => '#10b981',
-                    'pointBackgroundColor' => '#10b981',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->download_latency_iqm ? number_format($item->download_latency_iqm, 2) : null),
+                    'borderColor' => 'rgba(16, 185, 129)',
+                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'High (ms)',
-                    'data' => $results->map(fn ($item) => $item->download_latency_high ? number_format($item->download_latency_high, 2) : 0),
-                    'borderColor' => '#0ea5e9',
-                    'backgroundColor' => '#0ea5e9',
-                    'pointBackgroundColor' => '#0ea5e9',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->download_latency_high ? number_format($item->download_latency_high, 2) : null),
+                    'borderColor' => 'rgba(14, 165, 233)',
+                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'Low (ms)',
-                    'data' => $results->map(fn ($item) => $item->download_latency_low ? number_format($item->download_latency_low, 2) : 0),
-                    'borderColor' => '#8b5cf6',
-                    'backgroundColor' => '#8b5cf6',
-                    'pointBackgroundColor' => '#8b5cf6',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->download_latency_low ? number_format($item->download_latency_low, 2) : null),
+                    'borderColor' => 'rgba(139, 92, 246)',
+                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
@@ -87,6 +84,17 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'plugins' => [
+                'legend' => [
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
+                ],
+            ],
             'scales' => [
                 'y' => [
                     'beginAtZero' => true,

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -51,31 +51,28 @@ class RecentJitterChartWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Download (ms)',
-                    'data' => $results->map(fn ($item) => $item->download_jitter ? number_format($item->download_jitter, 2) : 0),
-                    'borderColor' => '#0ea5e9',
-                    'backgroundColor' => '#0ea5e9',
-                    'pointBackgroundColor' => '#0ea5e9',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->download_jitter ? number_format($item->download_jitter, 2) : null),
+                    'borderColor' => 'rgba(14, 165, 233)',
+                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'Upload (ms)',
-                    'data' => $results->map(fn ($item) => $item->upload_jitter ? number_format($item->upload_jitter, 2) : 0),
-                    'borderColor' => '#8b5cf6',
-                    'backgroundColor' => '#8b5cf6',
-                    'pointBackgroundColor' => '#8b5cf6',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->upload_jitter ? number_format($item->upload_jitter, 2) : null),
+                    'borderColor' => 'rgba(139, 92, 246)',
+                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'Ping (ms)',
-                    'data' => $results->map(fn ($item) => $item->ping_jitter ? number_format($item->ping_jitter, 2) : 0),
-                    'borderColor' => '#10b981',
-                    'backgroundColor' => '#10b981',
-                    'pointBackgroundColor' => '#10b981',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->ping_jitter ? number_format($item->ping_jitter, 2) : null),
+                    'borderColor' => 'rgba(16, 185, 129)',
+                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
@@ -87,6 +84,17 @@ class RecentJitterChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'plugins' => [
+                'legend' => [
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
+                ],
+            ],
             'scales' => [
                 'y' => [
                     'beginAtZero' => true,

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Helpers\Average;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
 
@@ -50,14 +51,24 @@ class RecentPingChartWidget extends ChartWidget
         return [
             'datasets' => [
                 [
-                    'label' => 'Ping (ms)',
+                    'label' => 'Ping',
                     'data' => $results->map(fn ($item) => $item->ping),
-                    'borderColor' => '#10b981',
-                    'backgroundColor' => '#10b981',
-                    'pointBackgroundColor' => '#10b981',
+                    'borderColor' => 'rgba(16, 185, 129)',
+                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
+                    'cubicInterpolationMode' => 'monotone',
+                    'tension' => 0.4,
+                ],
+                [
+                    'label' => 'Average',
+                    'data' => array_fill(0, count($results), Average::averagePing($results)),
+                    'borderColor' => 'rgb(243, 7, 6, 1)',
+                    'pointBackgroundColor' => 'rgb(243, 7, 6, 1)',
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
+                    'borderDash' => [5, 5],
+                    'pointRadius' => 0,
                 ],
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
@@ -69,7 +80,13 @@ class RecentPingChartWidget extends ChartWidget
         return [
             'plugins' => [
                 'legend' => [
-                    'display' => false,
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
                 ],
             ],
             'scales' => [

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
@@ -52,13 +53,23 @@ class RecentUploadChartWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Upload',
-                    'data' => $results->map(fn ($item) => ! blank($item->upload) ? Number::bitsToMagnitude(bits: $item->upload_bits, precision: 2, magnitude: 'mbit') : 0),
-                    'borderColor' => '#8b5cf6',
-                    'backgroundColor' => '#8b5cf6',
-                    'pointBackgroundColor' => '#8b5cf6',
+                    'data' => $results->map(fn ($item) => ! blank($item->upload) ? Number::bitsToMagnitude(bits: $item->upload_bits, precision: 2, magnitude: 'mbit') : null),
+                    'borderColor' => 'rgba(139, 92, 246)',
+                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
+                    'cubicInterpolationMode' => 'monotone',
+                    'tension' => 0.4,
+                ],
+                [
+                    'label' => 'Average',
+                    'data' => array_fill(0, count($results), Average::averageUpload($results)),
+                    'borderColor' => 'rgb(243, 7, 6, 1)',
+                    'pointBackgroundColor' => 'rgb(243, 7, 6, 1)',
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
+                    'borderDash' => [5, 5],
+                    'pointRadius' => 0,
                 ],
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
@@ -70,7 +81,13 @@ class RecentUploadChartWidget extends ChartWidget
         return [
             'plugins' => [
                 'legend' => [
-                    'display' => false,
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
                 ],
             ],
             'scales' => [

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -51,31 +51,28 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             'datasets' => [
                 [
                     'label' => 'Average (ms)',
-                    'data' => $results->map(fn ($item) => $item->upload_latency_iqm ? number_format($item->upload_latency_iqm, 2) : 0),
-                    'borderColor' => '#10b981',
-                    'backgroundColor' => '#10b981',
-                    'pointBackgroundColor' => '#10b981',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->upload_latency_iqm ? number_format($item->upload_latency_iqm, 2) : null),
+                    'borderColor' => 'rgba(16, 185, 129)',
+                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'High (ms)',
-                    'data' => $results->map(fn ($item) => $item->upload_latency_high ? number_format($item->upload_latency_high, 2) : 0),
-                    'borderColor' => '#0ea5e9',
-                    'backgroundColor' => '#0ea5e9',
-                    'pointBackgroundColor' => '#0ea5e9',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->upload_latency_high ? number_format($item->upload_latency_high, 2) : null),
+                    'borderColor' => 'rgba(14, 165, 233)',
+                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
                 [
                     'label' => 'Low (ms)',
-                    'data' => $results->map(fn ($item) => $item->upload_latency_low ? number_format($item->upload_latency_low, 2) : 0),
-                    'borderColor' => '#8b5cf6',
-                    'backgroundColor' => '#8b5cf6',
-                    'pointBackgroundColor' => '#8b5cf6',
-                    'fill' => false,
+                    'data' => $results->map(fn ($item) => $item->upload_latency_low ? number_format($item->upload_latency_low, 2) : null),
+                    'borderColor' => 'rgba(139, 92, 246)',
+                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
                 ],
@@ -87,6 +84,17 @@ class RecentUploadLatencyChartWidget extends ChartWidget
     protected function getOptions(): array
     {
         return [
+            'plugins' => [
+                'legend' => [
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
+                ],
+            ],
             'scales' => [
                 'y' => [
                     'beginAtZero' => true,

--- a/app/Helpers/Average.php
+++ b/app/Helpers/Average.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Helpers;
+
+use Illuminate\Support\Collection;
+
+class Average
+{
+    /**
+     * Calculate the average download speed from a collection of results.
+     */
+    public static function averageDownload(Collection $results, int $precision = 2, string $magnitude = 'mbit'): float
+    {
+        return round(
+            $results->map(function ($item) use ($magnitude, $precision) {
+                return ! blank($item->download)
+                    ? Number::bitsToMagnitude(bits: $item->download_bits, precision: $precision, magnitude: $magnitude)
+                    : 0;
+            })->avg(),
+            $precision
+        );
+    }
+
+    public static function averageUpload(Collection $results, int $precision = 2, string $magnitude = 'mbit'): float
+    {
+        return round(
+            $results->map(function ($item) use ($magnitude, $precision) {
+                return ! blank($item->upload)
+                    ? Number::bitsToMagnitude(bits: $item->upload_bits, precision: $precision, magnitude: $magnitude)
+                    : 0;
+            })->avg(),
+            $precision
+        );
+    }
+
+    public static function averagePing(Collection $results, int $precision = 2): float
+    {
+        $avgPing = $results->filter(function ($item) {
+            return ! blank($item->ping);
+        })->avg('ping');
+
+        return round($avgPing, $precision);
+    }
+}


### PR DESCRIPTION
## 📃 Description

This PR introduces new functionalities and updates the data display on the dashboard.

**Please double check the working of the time picker and env value before releasing to make sure it works as intended.** 

## 🪵 Changelog

### ➕ Added

- Add an Average line line to the Download, Upload & Ping Charts. Which shows the average over the selected time frame, but only when there is  2 or more data points in that time frame. 
      - To close https://github.com/alexjustesen/speedtest-tracker/issues/243 
      - to close https://github.com/alexjustesen/speedtest-tracker/issues/1244
      - to close https://github.com/alexjustesen/speedtest-tracker/issues/1408 
      - to close https://github.com/alexjustesen/speedtest-tracker/issues/1194


### ✏️ Changed


## 📷 Screenshots

