### PR TITLE
[Feature] Change toolbar button to Public Dashboard

### DIFF
--- a/app/Livewire/Topbar/RunSpeedtestAction.php
+++ b/app/Livewire/Topbar/RunSpeedtestAction.php
@@ -22,7 +22,7 @@ class RunSpeedtestAction extends Component implements HasActions, HasForms
     public function dashboardAction(): Action
     {
         return Action::make('home')
-            ->label('Dashboard')
+            ->label('Public Dashboard')
             ->icon('heroicon-o-chart-bar')
             ->iconPosition(IconPosition::Before)
             ->color('gray')


### PR DESCRIPTION
## 📃 Description

The button in the new toolbar is names "Dashboard" since its goes to the Public Dashboard it might be confusing with the normal Dashboard. This PR changes the name to Public Dashboard

## 🪵 Changelog

### ✏️ Changed

- Change Dashboard to Public Dashboard


## 📷 Screenshots

<img width="570" alt="image" src="https://github.com/user-attachments/assets/278ce3f0-6e2b-4fab-8b5a-8721a86343e6">