### PR TITLE
[Feature] Add Healhty to export and comments to column

### DIFF
--- a/app/Filament/Exports/ResultExporter.php
+++ b/app/Filament/Exports/ResultExporter.php
@@ -71,39 +71,48 @@ class ResultExporter extends Exporter
             ExportColumn::make('download_jitter')
                 ->state(function (Result $record): ?string {
                     return $record->download_jitter;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('upload_jitter')
                 ->state(function (Result $record): ?string {
                     return $record->upload_jitter;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('ping_jitter')
                 ->state(function (Result $record): ?string {
                     return $record->ping_jitter;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('upload_latency_high')
                 ->state(function (Result $record): ?string {
                     return $record->upload_latency_high;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('upload_latency_low')
                 ->state(function (Result $record): ?string {
                     return $record->upload_latency_low;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('upload_latency_avg')
                 ->state(function (Result $record): ?string {
                     return $record->upload_latency_iqm;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('download_latency_high')
                 ->state(function (Result $record): ?string {
                     return $record->download_latency_high;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('download_latency_low')
                 ->state(function (Result $record): ?string {
                     return $record->download_latency_low;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('download_latency_avg')
                 ->state(function (Result $record): ?string {
                     return $record->download_latency_iqm;
-                }),
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('result_url')
                 ->state(function (Result $record) {
                     return $record->result_url;
@@ -118,6 +127,11 @@ class ResultExporter extends Exporter
                 ->state(function (Result $record): string {
                     return $record->scheduled ? 'Yes' : 'No';
                 }),
+            ExportColumn::make('healthy')
+                ->state(function (Result $record): string {
+                    return $record->healthy ? 'Yes' : 'No';
+                })
+                ->enabledByDefault(false),
             ExportColumn::make('created_at'),
             ExportColumn::make('updated_at')
                 ->enabledByDefault(false),

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -140,7 +140,6 @@ class ResultResource extends Resource
                             Forms\Components\Placeholder::make('server_host')
                                 ->content(fn (Result $result): ?string => $result->server_host),
                             Forms\Components\Placeholder::make('comment')
-                                ->label('Comments')
                                 ->content(fn (Result $result): ?string => $result->comments),
                             Forms\Components\Checkbox::make('scheduled'),
                             Forms\Components\Checkbox::make('healthy'),

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -139,8 +139,12 @@ class ResultResource extends Resource
                                 ->content(fn (Result $result): ?string => $result->server_location),
                             Forms\Components\Placeholder::make('server_host')
                                 ->content(fn (Result $result): ?string => $result->server_host),
+                            Forms\Components\Placeholder::make('comment')
+                                ->label('Comments')
+                                ->content(fn (Result $result): ?string => $result->comments),
                             Forms\Components\Checkbox::make('scheduled'),
                             Forms\Components\Checkbox::make('healthy'),
+
                         ])
                         ->columns(1)
                         ->columnSpan([
@@ -309,6 +313,9 @@ class ResultResource extends Resource
                     }),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
+                    ->toggleable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('comments')
                     ->toggleable()
                     ->sortable(),
                 Tables\Columns\IconColumn::make('scheduled')

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -314,9 +314,6 @@ class ResultResource extends Resource
                     ->badge()
                     ->toggleable()
                     ->sortable(),
-                Tables\Columns\TextColumn::make('comments')
-                    ->toggleable()
-                    ->sortable(),
                 Tables\Columns\IconColumn::make('scheduled')
                     ->boolean()
                     ->toggleable()


### PR DESCRIPTION
## 📃 Description

This is a small QoL PR for the results table and export. 

## 🪵 Changelog

### ➕ Added

- Add `Healthy` to the results export.
- Add `comments` to the results  pop up 

### ✏️ Changed

- Disable all the  Download / Upload Latencies  form the export by default. 

## 📷 Screenshots
![Scherm­afbeelding 2024-11-28 om 09 28 36](https://github.com/user-attachments/assets/34727155-932b-41ef-8b4a-8dc72e5480ea)
![Scherm­afbeelding 2024-11-28 om 09 27 12](https://github.com/user-attachments/assets/e7e1d790-7425-41c5-ae8b-eb292533105e)

