### PR TITLE
Adding healthcheck to docker image

### DIFF
--- a/docker/8.3/Dockerfile
+++ b/docker/8.3/Dockerfile
@@ -63,6 +63,12 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
+HEALTHCHECK --interval=30s \
+            --timeout=5s \
+            --start-period=10s \
+            --retries=3 \
+            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:80/api/speedtest/latest" ]
+
 EXPOSE 80/tcp
 
 ENTRYPOINT ["start-container"]


### PR DESCRIPTION
## 📃 Description

Updated the docker image with a HEALTHCHECK directive to avoid the need for users to specify one themselves in a docker-compose.yml (for example).

Used some typical values for the check, happy to tweak if necessary.

## 🪵 Changelog

### ➕ Added

Added **HEALTHCHECK** to `docker/8.3/Dockerfile`.
