### PR TITLE
[Feature] Change Average to solid line & Add grace 

### DIFF
--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -70,7 +70,6 @@ class RecentDownloadChartWidget extends ChartWidget
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
-                    'borderDash' => [5, 5],
                     'pointRadius' => 0,
                 ],
             ],
@@ -96,6 +95,7 @@ class RecentDownloadChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -104,6 +104,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -69,7 +69,6 @@ class RecentPingChartWidget extends ChartWidget
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
-                    'borderDash' => [5, 5],
                     'pointRadius' => 0,
                 ],
             ],
@@ -94,6 +93,7 @@ class RecentPingChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -70,7 +70,6 @@ class RecentUploadChartWidget extends ChartWidget
                     'fill' => false,
                     'cubicInterpolationMode' => 'monotone',
                     'tension' => 0.4,
-                    'borderDash' => [5, 5],
                     'pointRadius' => 0,
                 ],
             ],
@@ -95,6 +94,7 @@ class RecentUploadChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -104,6 +104,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
             ],
         ];


### PR DESCRIPTION
## 📃 Description

This is a small QoL improvement for the charts. 

## 🪵 Changelog

### ➕ Added

- Add `grace` of 2 to some charts to not have the chart be at the bottom when there is a decrease in speed. 

### ✏️ Changed

- Change the Average to be a solid line instead of dotted, to fix the Legend looking strange
  - closes https://github.com/alexjustesen/speedtest-tracker/issues/1864

## 📷 Screenshots

Before: 
<img width="1266" alt="Scherm­afbeelding 2024-12-02 om 18 56 27" src="https://github.com/user-attachments/assets/3111f035-9779-491d-8869-3b68e5f663e3">

After
<img width="1252" alt="Scherm­afbeelding 2024-12-02 om 18 56 37" src="https://github.com/user-attachments/assets/6568e4d5-c8c1-4039-9a0a-79d345a2c91d">
