### PR TITLE
[Chore] Update policies to use Illuminate\Auth\Access\Response

### DIFF
--- a/app/Policies/ResultPolicy.php
+++ b/app/Policies/ResultPolicy.php
@@ -4,71 +4,75 @@ namespace App\Policies;
 
 use App\Models\Result;
 use App\Models\User;
+use Illuminate\Auth\Access\Response;
 
 class ResultPolicy
 {
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(User $user): bool
+    public function viewAny(User $user): Response
     {
-        return true;
+        return Response::allow();
     }
 
     /**
      * Determine whether the user can view the model.
      */
-    public function view(User $user, Result $result): bool
+    public function view(User $user, Result $result): Response
     {
-        return true;
+        return Response::allow();
     }
 
     /**
      * Determine whether the user can create models.
      */
-    public function create(User $user): bool
+    public function create(User $user): Response
     {
-        return false;
+        return Response::deny();
     }
 
     /**
      * Determine whether the user can update the model.
      */
-    public function update(User $user, Result $result): bool
+    public function update(User $user, Result $result): Response
     {
-        return $user->is_admin
-            || $user->is_user;
+        return Response::allow();
     }
 
     /**
      * Determine whether the user can bulk delete any model.
      */
-    public function deleteAny(User $user)
+    public function deleteAny(User $user): Response
     {
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to delete results.');
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(User $user, Result $result): bool
+    public function delete(User $user, Result $result): Response
     {
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to delete this result.');
     }
 
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore(User $user, Result $result): bool
+    public function restore(User $user, Result $result): Response
     {
-        return false; // soft deletes not used
+        return Response::deny(); // soft deletes not used
     }
 
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete(User $user, Result $result): bool
+    public function forceDelete(User $user, Result $result): Response
     {
-        return false; // soft deletes not used
+        return Response::deny(); // soft deletes not used
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -3,75 +3,89 @@
 namespace App\Policies;
 
 use App\Models\User;
+use Illuminate\Auth\Access\Response;
 
 class UserPolicy
 {
     /**
      * Determine whether the user can view any models.
      */
-    public function viewAny(User $user): bool
+    public function viewAny(User $user): Response
     {
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to view users.');
     }
 
     /**
      * Determine whether the user can view the model.
      */
-    public function view(User $user, User $model): bool
+    public function view(User $user, User $model): Response
     {
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to view this user.');
     }
 
     /**
      * Determine whether the user can create models.
      */
-    public function create(User $user): bool
+    public function create(User $user): Response
     {
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to create a new user.');
     }
 
     /**
      * Determine whether the user can update the model.
      */
-    public function update(User $user, User $model): bool
+    public function update(User $user, User $model): Response
     {
-        if ($user->id == $model->id) {
-            return true;
+        if ($model->is($user)) {
+            return Response::deny('You cannot update your own account.');
         }
 
-        return $user->is_admin;
+        return $user->is_admin
+            ? Response::allow()
+            : Response::deny('You do not have permission to update this user.');
     }
 
     /**
      * Determine whether the user can bulk delete any model.
      */
-    public function deleteAny(User $user): bool
+    public function deleteAny(User $user): Response
     {
-        return false;
+        return Response::deny('You do not have permission to delete users.');
     }
 
     /**
      * Determine whether the user can delete the model.
      */
-    public function delete(User $user, User $model): bool
+    public function delete(User $user, User $model): Response
     {
+        if ($model->is_admin) {
+            return Response::deny('You cannot delete an admin user.');
+        }
+
         return $user->is_admin
-            && ! $model->is_admin;
+            ? Response::allow()
+            : Response::deny('You do not have permission to delete this user.');
     }
 
     /**
      * Determine whether the user can restore the model.
      */
-    public function restore(User $user, User $model): bool
+    public function restore(User $user, User $model): Response
     {
-        return false; // soft deletes not used
+        return Response::deny(); // soft deletes not used
     }
 
     /**
      * Determine whether the user can permanently delete the model.
      */
-    public function forceDelete(User $user, User $model): bool
+    public function forceDelete(User $user, User $model): Response
     {
-        return false; // soft deletes not used
+        return Response::deny(); // soft deletes not used
     }
 }


### PR DESCRIPTION
## 📃 Description

- closes #1889 

## 🪵 Changelog

### ✏️ Changed

- no longer can update the authenticated user from the user resource, this should be done using your profile. 
- refactored policies to use `Illuminate\Auth\Access\Response` for permissions.