### PR TITLE
[Feature] Acknowledge threshold breaches in results table

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -392,6 +392,22 @@ class ResultResource extends Resource
                                 ->maxLength(500),
                         ])
                         ->modalButton('Save'),
+                    Tables\Actions\Action::make('updateHealthy')
+                        ->icon('heroicon-o-check-circle')
+                        ->hidden(fn (): bool => ! auth()->user()->is_admin && ! auth()->user()->is_user)
+                        ->hidden(fn (Result $record): bool => $record->status !== ResultStatus::Completed)
+                        ->mountUsing(fn (Forms\ComponentContainer $form, Result $record) => $form->fill([
+                            'healthy' => $record->healthy,
+                        ]))
+                        ->action(function (Result $record, array $data): void {
+                            $record->healthy = $data['healthy'];
+                            $record->save();
+                        })
+                        ->form([
+                            Forms\Components\Checkbox::make('healthy')
+                                ->label('Healthy'),
+                        ])
+                        ->modalButton('Save'),
                     Tables\Actions\DeleteAction::make(),
                 ]),
             ])


### PR DESCRIPTION
## 📃 Description

This PR adds the ability to edit the Healthy in case of a false positive.

Closes: https://github.com/alexjustesen/speedtest-tracker/issues/1920

## 🪵 Changelog

### ➕ Added

- Result table option to edit `Healthy`

## 📷 Screenshots

<img width="990" alt="Scherm­afbeelding 2024-12-17 om 22 08 44" src="https://github.com/user-attachments/assets/4e3358e7-db7c-414d-af6f-3f7263efc75b" />
<img width="363" alt="Scherm­afbeelding 2024-12-17 om 22 08 39" src="https://github.com/user-attachments/assets/107b2c63-f7b1-4292-bbae-ac79180ed482" />
