### PR TITLE
[Improvement] Add placeholder for failed test without message field

### DIFF
--- a/app/Helpers/Ookla.php
+++ b/app/Helpers/Ookla.php
@@ -20,7 +20,8 @@ class Ookla
                 return $decoded['message'];
             }
 
-            return ''; // If it's not valid JSON or doesn't contain "message", return an empty string
+            // Placeholder for invalid JSON or missing "message"
+            return 'An unexpected error occurred while running the Ookla CLI.';
         }, $messages);
 
         // Filter out empty messages and concatenate


### PR DESCRIPTION
## 📃 Description

Sometimes, the Ookla CLI fails to execute the test due to an unknown error. Unfortunately, in such cases, the CLI does not return a complete JSON error response. Instead, it only provides: 

```
{
    "error": "Cannot read: "
}
```

Our current logic expects a complete JSON response containing a `message` field. This PR introduces a placeholder error message for these cases, ensuring that failed tests are not left without an error message. 

As we cannot do anything about the reason of the failure this; 
- closes https://github.com/alexjustesen/speedtest-tracker/issues/1928
- closes https://github.com/alexjustesen/speedtest-tracker/issues/1862

## 🪵 Changelog

### ➕ Added

- A placeholder message for failed cases without a `message` field. 

