### PR TITLE
[Feature] Implement middleware to prevent overlapping execution of "RunSpeedtestJob"

### DIFF
--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -10,6 +10,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
 use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -31,6 +32,16 @@ class RunSpeedtestJob implements ShouldQueue
     public function __construct(
         public Result $result,
     ) {}
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [new WithoutOverlapping('run-speedtest')];
+    }
 
     /**
      * Execute the job.


### PR DESCRIPTION
## 🪵 Changelog

### ➕ Added

- `WithoutOverlapping` middleware on the `RunSpeedtestJob` to prevent multiple tests from running at the same time. This is not usually possible only if someone is using multiple queue workers.
