### PR TITLE
[Feature] Specify network interface to use

### DIFF
--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -64,7 +64,7 @@ class RunSpeedtestJob implements ShouldQueue
             '--accept-gdpr',
             '--format=json',
             $this->result->server_id ? '--server-id='.$this->result->server_id : null,
-            '--interface='.config('speedtest.interface') ?: null,
+            config('speedtest.interface') ? '--interface='.config('speedtest.interface') : null,
         ]);
 
         $process = new Process($command);

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -64,6 +64,7 @@ class RunSpeedtestJob implements ShouldQueue
             '--accept-gdpr',
             '--format=json',
             $this->result->server_id ? '--server-id='.$this->result->server_id : null,
+            '--interface='.config('speedtest.interface') ?: null,
         ]);
 
         $process = new Process($command);

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -35,6 +35,8 @@ return [
 
     'blocked_servers' => env('SPEEDTEST_BLOCKED_SERVERS'),
 
+    'interface' => env('SPEEDTEST_INTERFACE'),
+
     /**
      * IP filtering settings.
      */


### PR DESCRIPTION
## 📃 Description

This PR adds the option to specify the interface to use for the test. This way the user can specify is the tests need to run via a certain interface when using dockers `host` network or a specific docker network interface in case of multiple networks used for example a separate  IPv6 only network 

closes: https://github.com/alexjustesen/speedtest-tracker/issues/1301
closes: https://github.com/alexjustesen/speedtest-tracker/issues/615

Docs PR https://github.com/alexjustesen/speedtest-tracker-docs/pull/57

## 🪵 Changelog

### ➕ Added

- Add the `interface` argument  to the command
- Add the environment variable to specify the interface to use.
