### PR TITLE
[Bug] Fix placeholder erorr messages

### DIFF
--- a/app/Helpers/Ookla.php
+++ b/app/Helpers/Ookla.php
@@ -12,22 +12,22 @@ class Ookla
     public static function getErrorMessage(ProcessFailedException $exception): string
     {
         $messages = explode(PHP_EOL, $exception->getMessage());
+        $errorMessages = [];
 
-        // Extract only the "message" part from each JSON error message
-        $errorMessages = array_map(function ($message) {
+        foreach ($messages as $message) {
             $decoded = json_decode($message, true);
             if (json_last_error() === JSON_ERROR_NONE && isset($decoded['message'])) {
-                return $decoded['message'];
+                $errorMessages[] = $decoded['message'];
             }
+        }
 
-            // Placeholder for invalid JSON or missing "message"
-            return 'An unexpected error occurred while running the Ookla CLI.';
-        }, $messages);
+        // If no valid messages, use the placeholder
+        if (empty($errorMessages)) {
+            $errorMessages[] = 'An unexpected error occurred while running the Ookla CLI.';
+        }
 
-        // Filter out empty messages and concatenate
-        $errorMessage = implode(' | ', array_filter($errorMessages));
-
-        return $errorMessage;
+        // Remove duplicates and concatenate
+        return implode(' | ', array_unique($errorMessages));
     }
 
     public static function getConfigServers(): ?array


### PR DESCRIPTION
## 📃 Description

This PR fixed that the placeholder messages is not shown more then onces, or with a valid Ookla error message. 

### Replicate

You can generate a non valid error message by running; `while true; do speedtest --accept-license --accept-gdpr --servers --format=json; sleep 1; done` after a couple of seconds you will get a rate limit message and the CLI won't run anymore. 

## 🪵 Changelog

### 🔧 Fixed

- closes https://github.com/alexjustesen/speedtest-tracker/issues/1962

## 📷 Screenshots

Valid error json 
![image](https://github.com/user-attachments/assets/c66d63d5-d5d1-4a4b-b78e-6de07aa7eff3)

Non-valid error json. 
![image](https://github.com/user-attachments/assets/0415b896-22f0-46ed-a5a9-56c275e6fa5f)

