### PR TITLE
Charts improvements: default range filter and more granular time selection

### DIFF
--- a/app/Filament/Widgets/RecentChartWidget.php
+++ b/app/Filament/Widgets/RecentChartWidget.php
@@ -16,7 +16,8 @@ abstract class RecentChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = config('app.chart_default_filter');
+        $configDefaultChart = config('app.chart_default_filter');
+        $this->filter = array_key_exists($configDefaultChart, $this->getDateFilters()) ? $configDefaultChart : '24h';
     }
 
     protected function getPollingInterval(): ?string

--- a/app/Filament/Widgets/RecentChartWidget.php
+++ b/app/Filament/Widgets/RecentChartWidget.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Filament\Widgets;
+
+use App\Enums\ResultStatus;
+use App\Models\Result;
+use Filament\Widgets\ChartWidget;
+
+abstract class RecentChartWidget extends ChartWidget
+{
+    protected int|string|array $columnSpan = 'full';
+
+    protected static ?string $maxHeight = '250px';
+
+    public ?string $filter = '24h';
+
+    protected function getPollingInterval(): ?string
+    {
+        return config('speedtest.dashboard_polling');
+    }
+
+    protected function getDateFilters()
+    {
+        return [
+            '24h' => ['label' => 'Last 24h', 'date' => now()->subDay()],
+            'week' => ['label' => 'Last week', 'date' => now()->subWeek()],
+            'month' => ['label' => 'Last month', 'date' => now()->subMonth()],
+        ];
+    }
+
+    protected function getFilters(): ?array
+    {
+        return array_map(fn ($filter) => $filter['label'], $this->getDateFilters());
+    }
+
+    protected function getResults(string $column)
+    {
+        $filtersDates = array_map(fn ($filter) => $filter['date'], $this->getDateFilters());
+
+        return Result::query()
+            ->select(['id', $column, 'created_at'])
+            ->where('status', '=', ResultStatus::Completed)
+            ->where('created_at', '>=', $filtersDates[$this->filter])
+            ->orderBy('created_at')
+            ->get();
+    }
+
+    protected function getOptions(): array
+    {
+        return [
+            'plugins' => [
+                'legend' => [
+                    'display' => true,
+                ],
+                'tooltip' => [
+                    'enabled' => true,
+                    'mode' => 'index',
+                    'intersect' => false,
+                    'position' => 'nearest',
+                ],
+            ],
+            'scales' => [
+                'y' => [
+                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
+                ],
+            ],
+        ];
+    }
+
+    protected function getType(): string
+    {
+        return 'line';
+    }
+}

--- a/app/Filament/Widgets/RecentChartWidget.php
+++ b/app/Filament/Widgets/RecentChartWidget.php
@@ -27,9 +27,16 @@ abstract class RecentChartWidget extends ChartWidget
     protected function getDateFilters()
     {
         return [
-            '24h' => ['label' => 'Last 24h', 'date' => now()->subDay()],
-            'week' => ['label' => 'Last week', 'date' => now()->subWeek()],
-            'month' => ['label' => 'Last month', 'date' => now()->subMonth()],
+            '1h' => ['label' => 'Last hour', 'date' => now()->subHour()],
+            '3h' => ['label' => 'Last 3 hours', 'date' => now()->subHours(3)],
+            '6h' => ['label' => 'Last 6 hours', 'date' => now()->subHours(6)],
+            '12h' => ['label' => 'Last 12 hours', 'date' => now()->subHours(12)],
+            '24h' => ['label' => 'Last 24 hours', 'date' => now()->subDay()],
+            '1w' => ['label' => 'Last week', 'date' => now()->subWeek()],
+            '1m' => ['label' => 'Last month', 'date' => now()->subMonth()],
+            '3m' => ['label' => 'Last 3 months', 'date' => now()->subMonths(3)],
+            '6m' => ['label' => 'Last 6 months', 'date' => now()->subMonths(6)],
+            '1y' => ['label' => 'Last year', 'date' => now()->subYear()],
         ];
     }
 

--- a/app/Filament/Widgets/RecentChartWidget.php
+++ b/app/Filament/Widgets/RecentChartWidget.php
@@ -14,6 +14,11 @@ abstract class RecentChartWidget extends ChartWidget
 
     public ?string $filter = '24h';
 
+    public function mount(): void
+    {
+        $this->filter = config('app.chart_default_filter');
+    }
+
     protected function getPollingInterval(): ?string
     {
         return config('speedtest.dashboard_polling');

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -2,52 +2,16 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
 use App\Helpers\Average;
 use App\Helpers\Number;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
 
-class RecentDownloadChartWidget extends ChartWidget
+class RecentDownloadChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Download (Mbps)';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'download', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('download');
 
         return [
             'datasets' => [
@@ -75,34 +39,5 @@ class RecentDownloadChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                    'grace' => 2,
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -2,50 +2,13 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
-
-class RecentDownloadLatencyChartWidget extends ChartWidget
+class RecentDownloadLatencyChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Download Latency';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'data', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('data');
 
         return [
             'datasets' => [
@@ -85,33 +48,5 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                    'grace' => 2,
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -2,50 +2,13 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
-
-class RecentJitterChartWidget extends ChartWidget
+class RecentJitterChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Jitter';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'data', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('data');
 
         return [
             'datasets' => [
@@ -85,32 +48,5 @@ class RecentJitterChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -2,51 +2,15 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
 use App\Helpers\Average;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
 
-class RecentPingChartWidget extends ChartWidget
+class RecentPingChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Ping (ms)';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'ping', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('ping');
 
         return [
             'datasets' => [
@@ -74,33 +38,5 @@ class RecentPingChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                    'grace' => 2,
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -2,52 +2,16 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
 use App\Helpers\Average;
 use App\Helpers\Number;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
 
-class RecentUploadChartWidget extends ChartWidget
+class RecentUploadChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Upload (Mbps)';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'upload', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('upload');
 
         return [
             'datasets' => [
@@ -75,33 +39,5 @@ class RecentUploadChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                    'grace' => 2,
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -2,50 +2,13 @@
 
 namespace App\Filament\Widgets;
 
-use App\Enums\ResultStatus;
-use App\Models\Result;
-use Filament\Widgets\ChartWidget;
-
-class RecentUploadLatencyChartWidget extends ChartWidget
+class RecentUploadLatencyChartWidget extends RecentChartWidget
 {
     protected static ?string $heading = 'Upload Latency';
 
-    protected int|string|array $columnSpan = 'full';
-
-    protected static ?string $maxHeight = '250px';
-
-    public ?string $filter = '24h';
-
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
-
-    protected function getFilters(): ?array
-    {
-        return [
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-    }
-
     protected function getData(): array
     {
-        $results = Result::query()
-            ->select(['id', 'data', 'created_at'])
-            ->where('status', '=', ResultStatus::Completed)
-            ->when($this->filter == '24h', function ($query) {
-                $query->where('created_at', '>=', now()->subDay());
-            })
-            ->when($this->filter == 'week', function ($query) {
-                $query->where('created_at', '>=', now()->subWeek());
-            })
-            ->when($this->filter == 'month', function ($query) {
-                $query->where('created_at', '>=', now()->subMonth());
-            })
-            ->orderBy('created_at')
-            ->get();
+        $results = $this->getResults('data');
 
         return [
             'datasets' => [
@@ -85,33 +48,5 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ],
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
-    }
-
-    protected function getOptions(): array
-    {
-        return [
-            'plugins' => [
-                'legend' => [
-                    'display' => true,
-                ],
-                'tooltip' => [
-                    'enabled' => true,
-                    'mode' => 'index',
-                    'intersect' => false,
-                    'position' => 'nearest',
-                ],
-            ],
-            'scales' => [
-                'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
-                    'grace' => 2,
-                ],
-            ],
-        ];
-    }
-
-    protected function getType(): string
-    {
-        return 'line';
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -10,6 +10,8 @@ return [
 
     'chart_datetime_format' => env('CHART_DATETIME_FORMAT', 'M. j - G:i'),
 
+    'chart_default_filter' => env('CHART_DEFAULT_FILTER', '24h'),
+
     'datetime_format' => env('DATETIME_FORMAT', 'M. jS, Y g:ia'),
 
     'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),


### PR DESCRIPTION
## 📃 Description

Some improvements for charts

## 🪵 Changelog

### ➕ Added

- ability to set a default range filter in charts by an environment variable (fixes #448, #738, #1337)
- added more granular time selection chart filters (added: 1 hour, 3 hours, 6 hours, 12 hours, 3 months, 6 months, 1 year) (fixes #448)

### ✏️ Changed

- cleaned up some code and created a single class that contains all charts logic

## 📷 Screenshots

![](https://github.com/user-attachments/assets/ab12688b-d21b-4c4c-b29b-63e9d5e30aa4)
