### PR TITLE
[Fix] Picks a random server even when using a block list

### DIFF
--- a/app/Jobs/Ookla/SelectSpeedtestServerJob.php
+++ b/app/Jobs/Ookla/SelectSpeedtestServerJob.php
@@ -117,7 +117,9 @@ class SelectSpeedtestServerJob implements ShouldQueue
 
         $filtered = Arr::except($servers, $blocked);
 
-        return Arr::first($filtered);
+        return count($filtered) > 0
+            ? Arr::random($filtered)
+            : null;
     }
 
     /**


### PR DESCRIPTION
## 📃 Description

This fixes the issue mentioned in https://github.com/alexjustesen/speedtest-tracker/issues/1978. Now, when blocking servers, instead of using the first server from the list, a random server is chosen.

## 🪵 Changelog

### 🔧 Fixed

- `filterBlockedServers()` in **SelectSpeedtestServerJob.php** returns a random server instead of the first one from the list