### PR TITLE
[Feature] Implement configurable API rate limiting

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -39,10 +39,7 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->defineCustomIfStatements();
-
-        RateLimiter::for('api', function (Request $request) {
-            return Limit::perMinute(60)->by($request->user()?->id ?: $request->ip());
-        });
+        $this->setApiRateLimit();
 
         if (config('app.force_https')) {
             URL::forceScheme('https');
@@ -75,6 +72,13 @@ class AppServiceProvider extends ServiceProvider
          */
         Blade::if('filled', function (mixed $value) {
             return filled($value);
+        });
+    }
+
+    protected function setApiRateLimit(): void
+    {
+        RateLimiter::for('api', function (Request $request) {
+            return Limit::perMinute(config('api.rate_limit'));
         });
     }
 }

--- a/config/api.php
+++ b/config/api.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'rate_limit' => env('API_RATE_LIMIT', 60),
+
+];

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,6 @@ Route::get('/healthcheck', function () {
 Route::get('/speedtest/latest', GetLatestController::class)
     ->name('speedtest.latest');
 
-Route::middleware('auth:sanctum')->group(function () {
+Route::middleware(['auth:sanctum', 'throttle:api'])->group(function () {
     require __DIR__.'/api/v1/routes.php';
 });


### PR DESCRIPTION
## 📃 Description

This PR adds rate limiting to the API.

## 🪵 Changelog

### ➕ Added

- rate limit API responses, can be configured using `API_RATE_LIMIT` environment variable. The default rate limit is 60 requests per minute.
