### PR TITLE
[Bug] Fixed dynamic filters for `start_at` and `end_at` in ListResults API

### DIFF
--- a/app/Http/Controllers/Api/V1/ListResults.php
+++ b/app/Http/Controllers/Api/V1/ListResults.php
@@ -43,8 +43,16 @@ class ListResults extends ApiController
                 AllowedFilter::exact('healthy')->nullable(),
                 AllowedFilter::exact('status'),
                 AllowedFilter::exact('scheduled'),
-                AllowedFilter::operator('created_at', FilterOperator::DYNAMIC),
-                AllowedFilter::operator('updated_at', FilterOperator::DYNAMIC),
+                AllowedFilter::operator(
+                    name: 'start_at',
+                    internalName: 'created_at',
+                    filterOperator: FilterOperator::DYNAMIC,
+                ),
+                AllowedFilter::operator(
+                    name: 'end_at',
+                    internalName: 'created_at',
+                    filterOperator: FilterOperator::DYNAMIC,
+                ),
             ])
             ->allowedSorts([
                 'ping',


### PR DESCRIPTION
## 📃 Description

This PR fixes the filtering results on `api/v1/results` and point where the `created_at` date filter was not correctly aliased to allow for a range.

You can now filter this endpoint using `start_at` and `end_at`, both params are optional and expect a date or datetime.

## 🪵 Changelog

### ➕ Added

- `start_at` and `end_at` aliases for `created_at` so results can be correctly filtered by date range.

### 🗑️ Removed

- `updated_at` date filter, not needed IMO
