### PR TITLE
[Bug] Removed WithoutOverlapping middleware and refactored to use SkipIfBatchCancelled

### DIFF
--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -10,6 +10,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 
 class CheckForInternetConnectionJob implements ShouldQueue
 {
@@ -23,14 +24,20 @@ class CheckForInternetConnectionJob implements ShouldQueue
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
-        if ($this->batch()->cancelled()) {
-            return;
-        }
-
         $this->result->update([
             'status' => ResultStatus::Checking,
         ]);

--- a/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
+++ b/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
@@ -10,6 +10,7 @@ use App\Settings\ThresholdSettings;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 use Illuminate\Support\Arr;
 
 class BenchmarkSpeedtestJob implements ShouldQueue
@@ -26,13 +27,23 @@ class BenchmarkSpeedtestJob implements ShouldQueue
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
         $settings = app(ThresholdSettings::class);
 
-        if ($this->batch()->cancelled() || $settings->absolute_enabled == false) {
+        if ($settings->absolute_enabled == false) {
             return;
         }
 

--- a/app/Jobs/Ookla/CompleteSpeedtestJob.php
+++ b/app/Jobs/Ookla/CompleteSpeedtestJob.php
@@ -8,6 +8,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 
 class CompleteSpeedtestJob implements ShouldQueue
 {
@@ -21,14 +22,20 @@ class CompleteSpeedtestJob implements ShouldQueue
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
-        if ($this->batch()->cancelled()) {
-            return;
-        }
-
         $this->result->update([
             'status' => ResultStatus::Completed,
         ]);

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -10,7 +10,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Queue\Middleware\WithoutOverlapping;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
@@ -40,7 +40,9 @@ class RunSpeedtestJob implements ShouldQueue
      */
     public function middleware(): array
     {
-        return [new WithoutOverlapping('run-speedtest')];
+        return [
+            new SkipIfBatchCancelled,
+        ];
     }
 
     /**
@@ -48,10 +50,6 @@ class RunSpeedtestJob implements ShouldQueue
      */
     public function handle(): void
     {
-        if ($this->batch()->cancelled()) {
-            return;
-        }
-
         $this->result->update([
             'status' => ResultStatus::Running,
         ]);

--- a/app/Jobs/Ookla/SelectSpeedtestServerJob.php
+++ b/app/Jobs/Ookla/SelectSpeedtestServerJob.php
@@ -6,6 +6,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Exception\ProcessFailedException;
@@ -23,14 +24,20 @@ class SelectSpeedtestServerJob implements ShouldQueue
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
-        if ($this->batch()->cancelled()) {
-            return;
-        }
-
         // If the server id is already set, we don't need to do anything.
         if (Arr::get($this->result->data, 'server.id')) {
             return;

--- a/app/Jobs/Ookla/SkipSpeedtestJob.php
+++ b/app/Jobs/Ookla/SkipSpeedtestJob.php
@@ -10,6 +10,7 @@ use App\Models\Result;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
 
 class SkipSpeedtestJob implements ShouldQueue
 {
@@ -23,14 +24,20 @@ class SkipSpeedtestJob implements ShouldQueue
     ) {}
 
     /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
      * Execute the job.
      */
     public function handle(): void
     {
-        if ($this->batch()->cancelled()) {
-            return;
-        }
-
         /**
          * Only skip IPs for scheduled tests.
          */


### PR DESCRIPTION
## 📃 Description

This PR attempts to fix the issues described in #1975, it looks like failed/overlapping jobs are preventing additional speedtest jobs from being run.

## 🪵 Changelog

### ✏️ Changed

- refactored to use `SkipIfBatchCancelled` middleware on speedtest batch

### 🗑️ Removed

- `WithoutOverlapping` middleware from `RunSpeedtestJob`
