### PR TITLE
[Chore] Removed polling config

### DIFF
--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -438,7 +438,9 @@ class ResultResource extends Resource
             ])
             ->defaultSort('created_at', 'desc')
             ->paginated([5, 15, 25, 50, 100])
-            ->defaultPaginationPageOption(15);
+            ->defaultPaginationPageOption(15)
+            ->deferLoading()
+            ->poll('60s');
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ResultResource.php
+++ b/app/Filament/Resources/ResultResource.php
@@ -436,9 +436,7 @@ class ResultResource extends Resource
                         ->hidden(fn (): bool => ! Auth::user()->is_admin),
                 ])->dropdownPlacement('bottom-end'),
             ])
-            ->defaultSort('created_at', 'desc')
-            ->paginated([5, 15, 25, 50, 100])
-            ->defaultPaginationPageOption(15)
+            ->defaultSort('id', 'desc')
             ->deferLoading()
             ->poll('60s');
     }

--- a/app/Filament/Resources/ResultResource/Pages/ListResults.php
+++ b/app/Filament/Resources/ResultResource/Pages/ListResults.php
@@ -9,11 +9,6 @@ class ListResults extends ListRecords
 {
     protected static string $resource = ResultResource::class;
 
-    protected function getTablePollingInterval(): ?string
-    {
-        return config('speedtest.results_polling');
-    }
-
     protected function getHeaderWidgets(): array
     {
         return ResultResource::getWidgets();

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -16,12 +16,9 @@ class RecentDownloadChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -14,12 +14,9 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -14,12 +14,9 @@ class RecentJitterChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -15,12 +15,9 @@ class RecentPingChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -16,12 +16,9 @@ class RecentUploadChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -14,12 +14,9 @@ class RecentUploadLatencyChartWidget extends ChartWidget
 
     protected static ?string $maxHeight = '250px';
 
-    public ?string $filter = '24h';
+    protected static ?string $pollingInterval = '60s';
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    public ?string $filter = '24h';
 
     protected function getFilters(): ?array
     {

--- a/app/Filament/Widgets/StatsOverviewWidget.php
+++ b/app/Filament/Widgets/StatsOverviewWidget.php
@@ -12,10 +12,7 @@ class StatsOverviewWidget extends BaseWidget
 {
     public ?Result $result = null;
 
-    protected function getPollingInterval(): ?string
-    {
-        return config('speedtest.dashboard_polling');
-    }
+    protected static ?string $pollingInterval = '60s';
 
     protected function getCards(): array
     {

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -54,7 +54,6 @@ class AdminPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/Widgets'), for: 'App\\Filament\\Widgets')
             ->widgets([])
             ->databaseNotifications()
-            ->databaseNotificationsPolling(config('speedtest.notification_polling'))
             ->maxContentWidth(config('speedtest.content_width'))
             ->spa()
             ->middleware([

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -18,15 +18,6 @@ return [
     'public_dashboard' => env('PUBLIC_DASHBOARD', false),
 
     /**
-     * Polling settings.
-     */
-    'dashboard_polling' => env('DASHBOARD_POLLING', '60s'),
-
-    'notification_polling' => env('NOTIFICATION_POLLING', '60s'),
-
-    'results_polling' => env('RESULTS_POLLING', null),
-
-    /**
      * Speedtest settings.
      */
     'schedule' => env('SPEEDTEST_SCHEDULE', false),


### PR DESCRIPTION
## 📃 Description

Page / table / chart / notification refresh polling was introduced early on. This config has been removed and replaced with sensible defaults in preparation for a refactor of the dashboard and results table.

## 🪵 Changelog

### ✏️ Changed

- replaced polling config with sensible defaults
- defer loading of `Results` table
