### PR TITLE
[Bug] Removed spa mode

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -55,7 +55,6 @@ class AdminPanelProvider extends PanelProvider
             ->widgets([])
             ->databaseNotifications()
             ->maxContentWidth(config('speedtest.content_width'))
-            ->spa()
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,


### PR DESCRIPTION
## 📃 Description

"SPA mode" seemingly causes page load performance issues, this PR removes spa mode in an attempt to specifically get the dashboard and results table to load faster.

## 🪵 Changelog

### 🗑️ Removed

- `spa` mode from the admin panel
