### PR TITLE
add: Italian (it_IT) localization added

### DIFF
--- a/lang/it_IT/auth.php
+++ b/lang/it_IT/auth.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'Queste credenziali non corrispondono ai nostri archivi.',
+    'password' => 'La password fornita non è corretta.',
+    'throttle' => 'Troppi tentativi di accesso. Riprova tra :seconds secondi.',
+
+];

--- a/lang/it_IT/pagination.php
+++ b/lang/it_IT/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Precedente',
+    'next' => 'Successivo &raquo;',
+
+];

--- a/lang/it_IT/passwords.php
+++ b/lang/it_IT/passwords.php
@@ -1,0 +1,23 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'reset' => 'La tua password è stata reimpostata!',
+    'sent' => 'Ti abbiamo inviato via email il link per reimpostare la password!',
+    'password' => 'La password e la conferma devono corrispondere e contenere almeno sei caratteri.',
+    'throttled' => 'Per favore attendi prima di riprovare.',
+    'token' => 'Questo token di reimpostazione della password non è valido.',
+    'user' => "Non riusciamo a trovare un utente con quell'indirizzo email.",
+
+];

--- a/lang/it_IT/validation.php
+++ b/lang/it_IT/validation.php
@@ -1,0 +1,230 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => 'Il campo :attribute deve essere accettato.',
+    'accepted_if' => 'Il campo :attribute deve essere accettato quando :other è :value.',
+    'active_url' => 'Il campo :attribute deve essere un URL valido.',
+    'after' => 'Il campo :attribute deve essere una data successiva a :date.',
+    'after_or_equal' => 'Il campo :attribute deve essere una data successiva o uguale a :date.',
+    'alpha' => 'Il campo :attribute deve contenere solo lettere.',
+    'alpha_dash' => 'Il campo :attribute deve contenere solo lettere, numeri, trattini e trattini bassi.',
+    'alpha_num' => 'Il campo :attribute deve contenere solo lettere e numeri.',
+    'array' => 'Il campo :attribute deve essere un array.',
+    'ascii' => 'Il campo :attribute deve contenere solo caratteri alfanumerici e simboli a un byte.',
+    'before' => 'Il campo :attribute deve essere una data antecedente a :date.',
+    'before_or_equal' => 'Il campo :attribute deve essere una data precedente o uguale a :date.',
+    'between' => [
+        'array' => 'Il campo :attribute deve contenere tra :min e :max elementi.',
+        'file' => 'Il campo :attribute deve essere compreso tra :min e :max kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere compreso tra :min e :max.',
+        'string' => 'Il campo :attribute deve contenere tra :min e :max caratteri.',
+    ],
+    'boolean' => 'Il campo :attribute deve essere vero o falso.',
+    'can' => 'Il campo :attribute contiene un valore non autorizzato.',
+    'confirmed' => 'La conferma del campo :attribute non corrisponde.',
+    'current_password' => 'La password non è corretta.',
+    'date' => 'Il campo :attribute deve essere una data valida.',
+    'date_equals' => 'Il campo :attribute deve essere una data uguale a :date.',
+    'date_format' => 'Il campo :attribute deve corrispondere al formato :format.',
+    'decimal' => 'Il campo :attribute deve avere :decimal cifre decimali.',
+    'declined' => 'Il campo :attribute deve essere rifiutato.',
+    'declined_if' => 'Il campo :attribute deve essere rifiutato quando :other è :value.',
+    'different' => 'Il campo :attribute e :other devono essere diversi.',
+    'digits' => 'Il campo :attribute deve essere composto da :digits cifre.',
+    'digits_between' => 'Il campo :attribute deve essere compreso tra :min e :max cifre.',
+    'dimensions' => 'Il campo :attribute presenta dimensioni della foto non valide.',
+    'distinct' => 'Il campo :attribute ha un valore duplicato.',
+    'doesnt_end_with' => 'Il campo :attribute non deve terminare con uno dei seguenti: :values.',
+    'doesnt_start_with' => 'Il campo :attribute non deve iniziare con uno dei seguenti: :values.',
+    'email' => 'Il campo :attribute deve essere un indirizzo email valido.',
+    'ends_with' => 'Il campo :attribute deve terminare con uno dei seguenti: :values.',
+    'enum' => 'Il :attribute selezionato non valido.',
+    'exists' => 'Il :attribute selezionato non valido.',
+    'file' => 'Il campo :attribute deve essere un file.',
+    'filled' => 'Il campo :attribute deve avere un valore.',
+    'gt' => [
+        'array' => 'Il campo :attribute deve contenere più di :value elementi.',
+        'file' => 'Il campo :attribute deve essere maggiore di :value kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere maggiore di :value.',
+        'string' => 'Il campo :attribute deve essere maggiore di :value caratteri.',
+    ],
+    'gte' => [
+        'array' => 'Il campo :attribute deve contenere almeno :value elementi.',
+        'file' => 'Il campo :attribute deve essere maggiore o uguale a :value kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere maggiore o uguale a :value.',
+        'string' => 'Il campo :attribute deve essere maggiore o uguale a :value caratteri.',
+    ],
+    'image' => 'Il campo :attribute deve essere una foto.',
+    'in' => 'Il :attribute selezionato non è valido.',
+    'in_array' => 'Il campo :attribute deve esistere in :other.',
+    'integer' => 'Il campo :attribute deve essere un numero intero.',
+    'ip' => 'Il campo :attribute deve essere un indirizzo IP valido.',
+    'ipv4' => 'Il campo :attribute deve essere un indirizzo IPv4 valido.',
+    'ipv6' => 'Il campo :attribute deve essere un indirizzo IPv6 valido.',
+    'json' => 'Il campo :attribute deve essere una stringa JSON valida.',
+    'lowercase' => 'Il campo :attribute deve essere in minuscolo.',
+    'lt' => [
+        'array' => 'Il campo :attribute deve contenere meno di :value elementi.',
+        'file' => 'Il campo :attribute deve essere meno di :value kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere minore di :value.',
+        'string' => 'Il campo :attribute deve essere minore di :value caratteri.',
+    ],
+    'lte' => [
+        'array' => 'Il campo :attribute non deve avere più di :value elementi.',
+        'file' => 'Il campo :attribute deve essere minore di o uguale a :value kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere minore di o uguale a :value.',
+        'string' => 'Il campo :attribute deve essere minore di o uguale a :value caratteri.',
+    ],
+    'mac_address' => 'Il campo :attribute deve essere un indirizzo MAC valido.',
+    'max' => [
+        'array' => 'Il campo :attribute non deve avere più di :max elementi.',
+        'file' => 'Il campo :attribute non deve essere maggiore di :max kilobyte.',
+        'numeric' => 'Il campo :attribute non deve essere maggiore di :max.',
+        'string' => 'Il campo :attribute non deve essere maggiore di :max caratteri.',
+    ],
+    'max_digits' => 'Il campo :attribute non deve avere più di :max cifre.',
+    'mimes' => 'Il campo :attribute deve essere un file di tipo: :values.',
+    'mimetypes' => 'Il campo :attribute deve essere un file di tipo: :values.',
+    'min' => [
+        'array' => 'Il campo :attribute deve avere almeno :min elementi.',
+        'file' => 'Il campo :attribute deve essere almeno :min kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere almeno :min.',
+        'string' => 'Il campo :attribute deve essere almeno :min caratteri.',
+    ],
+    'min_digits' => 'Il campo :attribute deve avere almeno :min cifre.',
+    'missing' => 'Il campo :attribute deve essere mancante.',
+    'missing_if' => 'Il campo :attribute deve essere mancante quando :other è :value.',
+    'missing_unless' => 'Il campo :attribute deve essere mancante a meno che :other sia :value.',
+    'missing_with' => 'Il campo :attribute deve essere mancante quando :values è presente.',
+    'missing_with_all' => 'Il campo :attribute deve essere mancante quando :values sono presenti.',
+    'multiple_of' => 'Il campo :attribute deve essere un multiplo di :value.',
+    'not_in' => 'Il :attribute selezionato non è valido.',
+    'not_regex' => 'Il formato del campo :attribute non è valido.',
+    'numeric' => 'Il campo :attribute deve essere un numero.',
+    'password' => [
+        'letters' => 'Il campo :attribute deve contenere almeno una lettera.',
+        'mixed' => 'Il campo :attribute deve contenere almeno un carattere minuscolo e un carattere maiuscolo.',
+        'numbers' => 'Il campo :attribute deve contenere almeno un numero.',
+        'symbols' => 'Il campo :attribute deve contenere almeno un simbolo speciale.',
+        'uncompromised' => 'Il :attribute dato è apparso in un data leak. Per favore scegliere un :attribute differente.',
+    ],
+    'present' => 'Il campo :attribute deve essere presente.',
+    'prohibited' => 'Il campo :attribute è proibito.',
+    'prohibited_if' => 'Il campo :attribute è proibito quando :other è :value.',
+    'prohibited_unless' => 'Il campo :attribute è proibito a meno che :other sia in :values.',
+    'prohibits' => 'Il campo :attribute proibisce :other da essere presente.',
+    'regex' => 'Il formato del campo :attribute non è valido.',
+    'required' => 'Il campo :attribute è richiesto.',
+    'required_array_keys' => 'Il campo :attribute deve contenere inserimenti per: :values.',
+    'required_if' => 'Il campo :attribute è richiesto quando :other è :value.',
+    'required_if_accepted' => 'Il campo :attribute è richiesto quando :other è accettato.',
+    'required_unless' => 'Il campo :attribute è richiesto a meno che :other sia in :values.',
+    'required_with' => 'Il campo :attribute è richiesto quando :values è presente.',
+    'required_with_all' => 'Il campo :attribute è richiesto quando :values sono presenti.',
+    'required_without' => 'Il campo :attribute è richiesto quando :values non è presente.',
+    'required_without_all' => 'Il campo :attribute è richiesto quando nessuno dei :values sono presenti.',
+    'same' => 'Il campo :attribute non deve corrispondere a :other.',
+    'size' => [
+        'array' => 'Il campo :attribute deve contenere :size elementi.',
+        'file' => 'Il campo :attribute deve essere :size kilobyte.',
+        'numeric' => 'Il campo :attribute deve essere :size.',
+        'string' => 'Il campo :attribute deve essere :size caratteri.',
+    ],
+    'starts_with' => 'Il campo :attribute deve iniziare con uno dei seguenti: :values.',
+    'string' => 'Il campo :attribute deve essere una stringa.',
+    'timezone' => 'Il campo :attribute deve essere un fuso orario valido.',
+    'unique' => 'Il :attribute è già stato preso.',
+    'uploaded' => 'Il :attribute non è riuscito ad essere caricato.',
+    'uppercase' => 'Il campo :attribute deve essere maiuscolo.',
+    'url' => 'Il campo :attribute deve essere un URL valido.',
+    'ulid' => 'Il campo :attribute deve essere un ULID valido.',
+    'uuid' => 'Il campo :attribute deve essere un UUID valido.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [
+        'address' => 'indirizzo',
+        'age' => 'età',
+        'body' => 'corpo del testo',
+        'cell' => 'cella',
+        'city' => 'città',
+        'country' => 'nazione',
+        'date' => 'data',
+        'day' => 'giorno',
+        'excerpt' => 'sommario',
+        'first_name' => 'nome',
+        'gender' => 'identità di genere',
+        'marital_status' => 'stato civile',
+        'profession' => 'professione',
+        'nationality' => 'nazionalità',
+        'hour' => 'ora',
+        'last_name' => 'cognome',
+        'message' => 'messaggio',
+        'minute' => 'minuto',
+        'mobile' => 'cellulare',
+        'month' => 'mese',
+        'name' => 'nome',
+        'zipcode' => 'CAP',
+        'company_name' => 'nome azienda',
+        'neighborhood' => 'quartiere',
+        'number' => 'numero',
+        'password' => 'password',
+        'phone' => 'telefono',
+        'second' => 'secondo',
+        'sex' => 'sesso',
+        'state' => 'stato',
+        'street' => 'strada',
+        'subject' => 'oggetto',
+        'text' => 'testo',
+        'time' => 'ora',
+        'title' => 'titolo',
+        'username' => 'username',
+        'year' => 'anno',
+        'description' => 'descrizione',
+        'password_confirmation' => 'conferma password',
+        'current_password' => 'password corrente',
+        'complement' => 'complemento',
+        'modality' => 'modalità',
+        'category' => 'categoria',
+        'blood_type' => 'gruppo sanguigno',
+        'birth_date' => 'data di nascita',
+    ],
+];


### PR DESCRIPTION
## 📃 Description

Hello. I have created the Italian lang files. To do this I started from the `lang/eng` files as a base and I have translated the strings.

## 🪵 Changelog

### ➕ Added

- `lang/it_IT/auth.php`
- `lang/it_IT/pagination.php`
- `lang/it_IT/passwords.php`
- `lang/it_IT/validation.php`
