### PR TITLE
[Bug] Fix systemchecker in SpeedtestTrackerVersionProvider

### DIFF
--- a/app/Filament/VersionProviders/SpeedtestTrackerVersionProvider.php
+++ b/app/Filament/VersionProviders/SpeedtestTrackerVersionProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Filament\VersionProviders;
 
-use App\Services\SystemChecker;
 use Awcodes\FilamentVersions\Providers\Contracts\VersionProvider;
 
 class SpeedtestTrackerVersionProvider implements VersionProvider
@@ -15,7 +14,7 @@ class SpeedtestTrackerVersionProvider implements VersionProvider
     public function getVersion(): string
     {
         return app()->isProduction()
-            ? (new SystemChecker)->getLocalVersion()
+            ? (config('speedtest.build_version'))
             : config('app.env');
     }
 }


### PR DESCRIPTION
## 📃 Description

#2053 Introduced a bug that the systemchecker is still used in the `SpeedtestTrackerVersionProvider`. I missed that one.

closes https://github.com/alexjustesen/speedtest-tracker/issues/2077 
closes https://github.com/alexjustesen/speedtest-tracker/issues/2078

## 🪵 Changelog

### ✏️ Changed

- Change systemchecker to the config.
