### PR TITLE
[Feature] Add events for speedtest benchmark failed and passed

### DIFF
--- a/app/Events/SpeedtestBenchmarkFailed.php
+++ b/app/Events/SpeedtestBenchmarkFailed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestBenchmarkFailed
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Events/SpeedtestBenchmarkPassed.php
+++ b/app/Events/SpeedtestBenchmarkPassed.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestBenchmarkPassed
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
+++ b/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
@@ -3,7 +3,9 @@
 namespace App\Jobs\Ookla;
 
 use App\Enums\ResultStatus;
+use App\Events\SpeedtestBenchmarkFailed;
 use App\Events\SpeedtestBenchmarking;
+use App\Events\SpeedtestBenchmarkPassed;
 use App\Helpers\Benchmark;
 use App\Models\Result;
 use App\Settings\ThresholdSettings;
@@ -66,6 +68,10 @@ class BenchmarkSpeedtestJob implements ShouldQueue
             'benchmarks' => $benchmarks,
             'healthy' => $this->healthy,
         ]);
+
+        $this->healthy
+            ? SpeedtestBenchmarkPassed::dispatch($this->result)
+            : SpeedtestBenchmarkFailed::dispatch($this->result);
     }
 
     private function benchmark(Result $result, ThresholdSettings $settings): array


### PR DESCRIPTION
## 📃 Description

This PR adds events for failed and passed speedtest benchmarks.

## 🪵 Changelog

### ➕ Added

- `SpeedtestBenchmarkFailed` and `SpeedtestBenchmarkPassed` events
