### PR TITLE
icanhazip alternative env variable and logic

### DIFF
--- a/app/Actions/GetExternalIpAddress.php
+++ b/app/Actions/GetExternalIpAddress.php
@@ -8,6 +8,12 @@ use Illuminate\Support\Str;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Throwable;
 
+if (! config('speedtest.externalip_url')) {
+    $fetch_url = 'https://icanhazip.com/';
+} else {
+    $fetch_url = $speedtest.externalip_url;
+}
+
 class GetExternalIpAddress
 {
     use AsAction;
@@ -15,9 +21,14 @@ class GetExternalIpAddress
     public function handle(): bool|string
     {
         try {
+            if (! config('speedtest.externalip_url')) {
+                $fetch_url = $speedtest.externalip_url;
+            } else {
+                $fetch_url = "https://icanhazip.com/";
+            }
             $response = Http::retry(3, 100)
                 ->timeout(5)
-                ->get(url: 'https://icanhazip.com/');
+                ->get(url: $fetch_url);
         } catch (Throwable $e) {
             Log::error('Failed to fetch external IP address.', [$e->getMessage()]);
 

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -28,6 +28,8 @@ return [
 
     'interface' => env('SPEEDTEST_INTERFACE'),
 
+    'externalip_url' => env('SPEEDTEST_EXTERNALIP_URL'),
+
     /**
      * IP filtering settings.
      */


### PR DESCRIPTION
## 📃 Description

Added environment variable to override icanhazip.com hardcoding but fall back if not found.

### ➕ Added

- SPEEDTEST_EXTERNALIP_URL environment variable and logic to specify alternate ip services:
- "https://ifconfig.io" or "https://ipconfig.io/me" or "https://ifconfig.me"
- Falls back to https://icanhazip.com if env variable is not specified
- tested with dev laravel environment - but please scrutinize my changes
- per feature request at https://github.com/alexjustesen/speedtest-tracker/issues/2111
- (feel free to quash if issues, I'm way more fluent in python than php)


