### PR TITLE
[Bug] Separate  CheckInternetConnection from GetExternalIpAddress

### DIFF
--- a/app/Actions/CheckInternetConnection.php
+++ b/app/Actions/CheckInternetConnection.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Throwable;
+
+class CheckInternetConnection
+{
+    use AsAction;
+
+    public function handle(): bool|string
+    {
+        try {
+            $response = Http::retry(3, 100)
+                ->timeout(5)
+                ->get(config('speedtest.externalip_url'));
+
+            if (! $response->ok()) {
+                return false;
+            }
+
+            return Str::trim($response->body());
+        } catch (Throwable $e) {
+            Log::error('Failed to check internet connection.', [$e->getMessage()]);
+
+            return false;
+        }
+    }
+}

--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -2,7 +2,7 @@
 
 namespace App\Jobs;
 
-use App\Actions\GetExternalIpAddress;
+use App\Actions\CheckInternetConnection;
 use App\Enums\ResultStatus;
 use App\Events\SpeedtestChecking;
 use App\Events\SpeedtestFailed;
@@ -44,7 +44,7 @@ class CheckForInternetConnectionJob implements ShouldQueue
 
         SpeedtestChecking::dispatch($this->result);
 
-        if (GetExternalIpAddress::run() !== false) {
+        if (CheckInternetConnection::run() !== false) {
             return;
         }
 

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -28,6 +28,8 @@ return [
 
     'interface' => env('SPEEDTEST_INTERFACE'),
 
+    'externalip_url' => env('SPEEDTEST_EXTERNALIP_URL', 'https://icanhazip.com'),
+
     /**
      * IP filtering settings.
      */


### PR DESCRIPTION
## 📃 Description

This PR adds and `CheckInternetConnection` action that checks if the Internet connections is active before starting the test. 

Closes: https://github.com/alexjustesen/speedtest-tracker/issues/2111

## 🪵 Changelog

### ➕ Added

- Add `CheckInternetConnection` action to check for a http 200 code 

### ✏️ Changed

- Remove `GetExternalIpAddress` for the internet check

