### PR TITLE
Add Support for DingTalk and WeCom Notifications via Webhook

### DIFF
--- a/app/Actions/Notifications/SendDingTalkTestNotification.php
+++ b/app/Actions/Notifications/SendDingTalkTestNotification.php
@@ -24,7 +24,7 @@ class SendDingTalkTestNotification
         $payload = [
             'msgtype' => 'text',
             'text' => [
-                'content' => '👋 Testing the Webhook notification channel on Speedtest Tracker.',
+                'content' => '👋 Testing the DingTalk notification channel on Speedtest Tracker.',
             ],
         ];
 

--- a/app/Actions/Notifications/SendDingTalkTestNotification.php
+++ b/app/Actions/Notifications/SendDingTalkTestNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Notifications;
+
+use Filament\Notifications\Notification;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendDingTalkTestNotification
+{
+    use AsAction;
+
+    public function handle(array $webhooks)
+    {
+        if (! count($webhooks)) {
+            Notification::make()
+                ->title('You need to add dingtalk urls!')
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'text',
+            'text' => [
+                'content' => '👋 Testing the Webhook notification channel on Speedtest Tracker.',
+            ],
+        ];
+
+        foreach ($webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+
+        Notification::make()
+            ->title('Test dingtalk notification sent.')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Actions/Notifications/SendWeComTestNotification.php
+++ b/app/Actions/Notifications/SendWeComTestNotification.php
@@ -24,7 +24,7 @@ class SendWeComTestNotification
         $payload = [
             'msgtype' => 'text',
             'text' => [
-                'content' => '👋 Testing the Webhook notification channel on Speedtest Tracker.',
+                'content' => '👋 Testing the WeCom notification channel on Speedtest Tracker.',
             ],
         ];
 

--- a/app/Actions/Notifications/SendWeComTestNotification.php
+++ b/app/Actions/Notifications/SendWeComTestNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Notifications;
+
+use Filament\Notifications\Notification;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendWeComTestNotification
+{
+    use AsAction;
+
+    public function handle(array $webhooks)
+    {
+        if (! count($webhooks)) {
+            Notification::make()
+                ->title('You need to add wecom urls!')
+                ->warning()
+                ->send();
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'text',
+            'text' => [
+                'content' => '👋 Testing the Webhook notification channel on Speedtest Tracker.',
+            ],
+        ];
+
+        foreach ($webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+
+        Notification::make()
+            ->title('Test wecom notification sent.')
+            ->success()
+            ->send();
+    }
+}

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -13,6 +13,7 @@ use App\Actions\Notifications\SendPushoverTestNotification;
 use App\Actions\Notifications\SendSlackTestNotification;
 use App\Actions\Notifications\SendTelegramTestNotification;
 use App\Actions\Notifications\SendWebhookTestNotification;
+use App\Actions\Notifications\SendWeComTestNotification;
 use App\Settings\NotificationSettings;
 use Filament\Forms;
 use Filament\Forms\Form;
@@ -562,6 +563,51 @@ class NotificationPage extends SettingsPage
                                         'default' => 1,
                                         'md' => 2,
                                     ]),
+
+                                Forms\Components\Section::make('WeCom')
+                                    ->schema([
+                                        Forms\Components\Toggle::make('wecom_enabled')
+                                            ->label('Enable wecom notifications')
+                                            ->reactive()
+                                            ->columnSpanFull(),
+                                        Forms\Components\Grid::make([
+                                            'default' => 1,
+                                        ])
+                                            ->hidden(fn (Forms\Get $get) => $get('wecom_enabled') !== true)
+                                            ->schema([
+                                                Forms\Components\Fieldset::make('Triggers')
+                                                    ->schema([
+                                                        Forms\Components\Toggle::make('wecom_on_speedtest_run')
+                                                            ->label('Notify on every speedtest run')
+                                                            ->columnSpan(2),
+                                                        Forms\Components\Toggle::make('wecom_on_threshold_failure')
+                                                            ->label('Notify on threshold failures')
+                                                            ->columnSpan(2),
+                                                    ]),
+                                                Forms\Components\Repeater::make('wecom_webhooks')
+                                                    ->label('Webhooks')
+                                                    ->schema([
+                                                        Forms\Components\TextInput::make('url')
+                                                            ->placeholder('https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=xxxxxxxx')
+                                                            ->maxLength(2000)
+                                                            ->required()
+                                                            ->url(),
+                                                    ])
+                                                    ->columnSpanFull(),
+                                                Forms\Components\Actions::make([
+                                                    Forms\Components\Actions\Action::make('test wecom')
+                                                        ->label('Test wecom channel')
+                                                        ->action(fn (Forms\Get $get) => SendWeComTestNotification::run(webhooks: $get('wecom_webhooks')))
+                                                        ->hidden(fn (Forms\Get $get) => ! count($get('wecom_webhooks'))),
+                                                ]),
+                                            ]),
+                                    ])
+                                    ->compact()
+                                    ->columns([
+                                        'default' => 1,
+                                        'md' => 2,
+                                    ]),
+
                             ])
                             ->columnSpan([
                                 'md' => 2,

--- a/app/Filament/Pages/Settings/NotificationPage.php
+++ b/app/Filament/Pages/Settings/NotificationPage.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages\Settings;
 
 use App\Actions\Notifications\SendDatabaseTestNotification;
+use App\Actions\Notifications\SendDingTalkTestNotification;
 use App\Actions\Notifications\SendDiscordTestNotification;
 use App\Actions\Notifications\SendGotifyTestNotification;
 use App\Actions\Notifications\SendHealthCheckTestNotification;
@@ -509,6 +510,50 @@ class NotificationPage extends SettingsPage
                                                         ->label('Test webhook channel')
                                                         ->action(fn (Forms\Get $get) => SendWebhookTestNotification::run(webhooks: $get('webhook_urls')))
                                                         ->hidden(fn (Forms\Get $get) => ! count($get('webhook_urls'))),
+                                                ]),
+                                            ]),
+                                    ])
+                                    ->compact()
+                                    ->columns([
+                                        'default' => 1,
+                                        'md' => 2,
+                                    ]),
+
+                                Forms\Components\Section::make('DingTalk')
+                                    ->schema([
+                                        Forms\Components\Toggle::make('dingtalk_enabled')
+                                            ->label('Enable dingtalk notifications')
+                                            ->reactive()
+                                            ->columnSpanFull(),
+                                        Forms\Components\Grid::make([
+                                            'default' => 1,
+                                        ])
+                                            ->hidden(fn (Forms\Get $get) => $get('dingtalk_enabled') !== true)
+                                            ->schema([
+                                                Forms\Components\Fieldset::make('Triggers')
+                                                    ->schema([
+                                                        Forms\Components\Toggle::make('dingtalk_on_speedtest_run')
+                                                            ->label('Notify on every speedtest run')
+                                                            ->columnSpan(2),
+                                                        Forms\Components\Toggle::make('dingtalk_on_threshold_failure')
+                                                            ->label('Notify on threshold failures')
+                                                            ->columnSpan(2),
+                                                    ]),
+                                                Forms\Components\Repeater::make('dingtalk_webhooks')
+                                                    ->label('Webhooks')
+                                                    ->schema([
+                                                        Forms\Components\TextInput::make('url')
+                                                            ->placeholder('https://oapi.dingtalk.com/robot/send?access_token=xxxxxxxx')
+                                                            ->maxLength(2000)
+                                                            ->required()
+                                                            ->url(),
+                                                    ])
+                                                    ->columnSpanFull(),
+                                                Forms\Components\Actions::make([
+                                                    Forms\Components\Actions\Action::make('test dingtalk')
+                                                        ->label('Test dingtalk channel')
+                                                        ->action(fn (Forms\Get $get) => SendDingTalkTestNotification::run(webhooks: $get('dingtalk_webhooks')))
+                                                        ->hidden(fn (Forms\Get $get) => ! count($get('dingtalk_webhooks'))),
                                                 ]),
                                             ]),
                                     ])

--- a/app/Listeners/DingTalk/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/DingTalk/SendSpeedtestCompletedNotification.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Listeners\DingTalk;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestCompletedNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings;
+
+        if (! $notificationSettings->dingtalk_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->dingtalk_on_speedtest_run) {
+            return;
+        }
+
+        if (! count($notificationSettings->dingtalk_webhooks)) {
+            Log::warning('DingTalk urls not found, check dingtalk notification channel settings.');
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'markdown',
+            'markdown' => [
+                'title' => sprintf('Speedtest Completed - #%s', $event->result->id),
+                'text' => view('dingtalk.speedtest-completed', [
+                    'id' => $event->result->id,
+                    'service' => Str::title($event->result->service->getLabel()),
+                    'serverName' => $event->result->server_name,
+                    'serverId' => $event->result->server_id,
+                    'isp' => $event->result->isp,
+                    'ping' => round($event->result->ping).' ms',
+                    'download' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+                    'upload' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+                    'packetLoss' => is_numeric($event->result->packet_loss) ? round($event->result->packet_loss, 2) : 'n/a',
+                    'speedtest_url' => $event->result->result_url,
+                    'url' => url('/admin/results'),
+                ])->render(),
+            ],
+        ];
+
+        foreach ($notificationSettings->dingtalk_webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+}

--- a/app/Listeners/DingTalk/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/DingTalk/SendSpeedtestThresholdNotification.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Listeners\DingTalk;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use App\Settings\ThresholdSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestThresholdNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings;
+
+        if (! $notificationSettings->dingtalk_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->dingtalk_on_threshold_failure) {
+            return;
+        }
+
+        if (! count($notificationSettings->dingtalk_webhooks)) {
+            Log::warning('DingTalk urls not found, check dingtalk notification channel settings.');
+
+            return;
+        }
+
+        $thresholdSettings = new ThresholdSettings;
+
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
+        $failed = [];
+
+        if ($thresholdSettings->absolute_download > 0) {
+            array_push($failed, $this->absoluteDownloadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_upload > 0) {
+            array_push($failed, $this->absoluteUploadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_ping > 0) {
+            array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        $failed = array_filter($failed);
+
+        if (! count($failed)) {
+            Log::warning('Failed dingtalk thresholds not found, won\'t send notification.');
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'markdown',
+            'markdown' => [
+                'title' => sprintf('Speedtest Threshold Breached - #%s', $event->result->id),
+                'text' => view('dingtalk.speedtest-threshold', [
+                    'id' => $event->result->id,
+                    'service' => Str::title($event->result->service->getLabel()),
+                    'serverName' => $event->result->server_name,
+                    'serverId' => $event->result->server_id,
+                    'isp' => $event->result->isp,
+                    'metrics' => $failed,
+                    'speedtest_url' => $event->result->result_url,
+                    'url' => url('/admin/results'),
+                ])->render(),
+            ],
+        ];
+
+        foreach ($notificationSettings->dingtalk_webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+
+    /**
+     * Build webhook notification if absolute download threshold is breached.
+     */
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Download',
+            'threshold' => $thresholdSettings->absolute_download.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build webhook notification if absolute upload threshold is breached.
+     */
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Upload',
+            'threshold' => $thresholdSettings->absolute_upload.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build webhook notification if absolute ping threshold is breached.
+     */
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Ping',
+            'threshold' => $thresholdSettings->absolute_ping.' ms',
+            'value' => round($event->result->ping, 2).' ms',
+        ];
+    }
+}

--- a/app/Listeners/WeCom/SendSpeedtestCompletedNotification.php
+++ b/app/Listeners/WeCom/SendSpeedtestCompletedNotification.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Listeners\WeCom;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestCompletedNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings;
+
+        if (! $notificationSettings->wecom_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->wecom_on_speedtest_run) {
+            return;
+        }
+
+        if (! count($notificationSettings->wecom_webhooks)) {
+            Log::warning('WeCom urls not found, check wecom notification channel settings.');
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'markdown',
+            'markdown' => [
+                'content' => view('wecom.speedtest-completed', [
+                    'id' => $event->result->id,
+                    'service' => Str::title($event->result->service->getLabel()),
+                    'serverName' => $event->result->server_name,
+                    'serverId' => $event->result->server_id,
+                    'isp' => $event->result->isp,
+                    'ping' => round($event->result->ping).' ms',
+                    'download' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+                    'upload' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+                    'packetLoss' => is_numeric($event->result->packet_loss) ? round($event->result->packet_loss, 2) : 'n/a',
+                    'speedtest_url' => $event->result->result_url,
+                    'url' => url('/admin/results'),
+                ])->render(),
+            ],
+        ];
+
+        foreach ($notificationSettings->wecom_webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+}

--- a/app/Listeners/WeCom/SendSpeedtestThresholdNotification.php
+++ b/app/Listeners/WeCom/SendSpeedtestThresholdNotification.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Listeners\WeCom;
+
+use App\Events\SpeedtestCompleted;
+use App\Helpers\Number;
+use App\Settings\NotificationSettings;
+use App\Settings\ThresholdSettings;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Spatie\WebhookServer\WebhookCall;
+
+class SendSpeedtestThresholdNotification
+{
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestCompleted $event): void
+    {
+        $notificationSettings = new NotificationSettings;
+
+        if (! $notificationSettings->wecom_enabled) {
+            return;
+        }
+
+        if (! $notificationSettings->wecom_on_threshold_failure) {
+            return;
+        }
+
+        if (! count($notificationSettings->wecom_webhooks)) {
+            Log::warning('WeCom urls not found, check wecom notification channel settings.');
+
+            return;
+        }
+
+        $thresholdSettings = new ThresholdSettings;
+
+        if (! $thresholdSettings->absolute_enabled) {
+            return;
+        }
+
+        $failed = [];
+
+        if ($thresholdSettings->absolute_download > 0) {
+            array_push($failed, $this->absoluteDownloadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_upload > 0) {
+            array_push($failed, $this->absoluteUploadThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        if ($thresholdSettings->absolute_ping > 0) {
+            array_push($failed, $this->absolutePingThreshold(event: $event, thresholdSettings: $thresholdSettings));
+        }
+
+        $failed = array_filter($failed);
+
+        if (! count($failed)) {
+            Log::warning('Failed wecom thresholds not found, won\'t send notification.');
+
+            return;
+        }
+
+        $payload = [
+            'msgtype' => 'markdown',
+            'markdown' => [
+                'content' => view('wecom.speedtest-threshold', [
+                    'id' => $event->result->id,
+                    'service' => Str::title($event->result->service->getLabel()),
+                    'serverName' => $event->result->server_name,
+                    'serverId' => $event->result->server_id,
+                    'isp' => $event->result->isp,
+                    'metrics' => $failed,
+                    'speedtest_url' => $event->result->result_url,
+                    'url' => url('/admin/results'),
+                ])->render(),
+            ],
+        ];
+
+        foreach ($notificationSettings->wecom_webhooks as $webhook) {
+            WebhookCall::create()
+                ->url($webhook['url'])
+                ->payload($payload)
+                ->doNotSign()
+                ->dispatch();
+        }
+    }
+
+    /**
+     * Build webhook notification if absolute download threshold is breached.
+     */
+    protected function absoluteDownloadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteDownloadThresholdFailed($thresholdSettings->absolute_download, $event->result->download)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Download',
+            'threshold' => $thresholdSettings->absolute_download.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->download_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build webhook notification if absolute upload threshold is breached.
+     */
+    protected function absoluteUploadThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absoluteUploadThresholdFailed($thresholdSettings->absolute_upload, $event->result->upload)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Upload',
+            'threshold' => $thresholdSettings->absolute_upload.' Mbps',
+            'value' => Number::toBitRate(bits: $event->result->upload_bits, precision: 2),
+        ];
+    }
+
+    /**
+     * Build webhook notification if absolute ping threshold is breached.
+     */
+    protected function absolutePingThreshold(SpeedtestCompleted $event, ThresholdSettings $thresholdSettings): bool|array
+    {
+        if (! absolutePingThresholdFailed($thresholdSettings->absolute_ping, $event->result->ping)) {
+            return false;
+        }
+
+        return [
+            'name' => 'Ping',
+            'threshold' => $thresholdSettings->absolute_ping.' ms',
+            'value' => round($event->result->ping, 2).' ms',
+        ];
+    }
+}

--- a/app/Settings/NotificationSettings.php
+++ b/app/Settings/NotificationSettings.php
@@ -86,6 +86,14 @@ class NotificationSettings extends Settings
 
     public ?array $gotify_webhooks;
 
+    public bool $dingtalk_enabled;
+
+    public bool $dingtalk_on_speedtest_run;
+
+    public bool $dingtalk_on_threshold_failure;
+
+    public ?array $dingtalk_webhooks;
+
     public static function group(): string
     {
         return 'notification';

--- a/app/Settings/NotificationSettings.php
+++ b/app/Settings/NotificationSettings.php
@@ -94,6 +94,14 @@ class NotificationSettings extends Settings
 
     public ?array $dingtalk_webhooks;
 
+    public bool $wecom_enabled;
+
+    public bool $wecom_on_speedtest_run;
+
+    public bool $wecom_on_threshold_failure;
+
+    public ?array $wecom_webhooks;
+
     public static function group(): string
     {
         return 'notification';

--- a/database/settings/2025_04_08_034447_create_dingtalk_notification_settings.php
+++ b/database/settings/2025_04_08_034447_create_dingtalk_notification_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('notification.dingtalk_enabled', false);
+        $this->migrator->add('notification.dingtalk_on_speedtest_run', false);
+        $this->migrator->add('notification.dingtalk_on_threshold_failure', false);
+        $this->migrator->add('notification.dingtalk_webhooks', null);
+    }
+};

--- a/database/settings/2025_04_08_065526_create_wecom_notification_settings.php
+++ b/database/settings/2025_04_08_065526_create_wecom_notification_settings.php
@@ -1,0 +1,14 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('notification.wecom_enabled', false);
+        $this->migrator->add('notification.wecom_on_speedtest_run', false);
+        $this->migrator->add('notification.wecom_on_threshold_failure', false);
+        $this->migrator->add('notification.wecom_webhooks', null);
+    }
+};

--- a/resources/views/dingtalk/speedtest-completed.blade.php
+++ b/resources/views/dingtalk/speedtest-completed.blade.php
@@ -1,0 +1,13 @@
+*Speedtest Completed - #{{ $id }}*
+
+A new speedtest on *{{ config('app.name') }}* was completed using *{{ $service }}*.
+
+- *Server name:* {{ $serverName }}
+- *Server ID:* {{ $serverId }}
+- **ISP:** {{ $isp }}
+- *Ping:* {{ $ping }}
+- *Download:* {{ $download }}
+- *Upload:* {{ $upload }}
+- **Packet Loss:** {{ $packetLoss }}**%**
+- **Ookla Speedtest:** {{ $speedtest_url }}
+- **URL:** {{ $url }}

--- a/resources/views/dingtalk/speedtest-threshold.blade.php
+++ b/resources/views/dingtalk/speedtest-threshold.blade.php
@@ -1,0 +1,9 @@
+**Speedtest Threshold Breached - #{{ $id }}**
+
+A new speedtest on **{{ config('app.name') }}** was completed using **{{ $service }}** on **{{ $isp }}** but a threshold was breached.
+
+@foreach ($metrics as $item)
+- **{{ $item['name'] }}** {{ $item['threshold'] }}: {{ $item['value'] }}
+@endforeach
+- **Ookla Speedtest:** {{ $speedtest_url }}
+- **URL:** {{ $url }}

--- a/resources/views/wecom/speedtest-completed.blade.php
+++ b/resources/views/wecom/speedtest-completed.blade.php
@@ -1,0 +1,13 @@
+*Speedtest Completed - #{{ $id }}*
+
+A new speedtest on *{{ config('app.name') }}* was completed using *{{ $service }}*.
+
+- *Server name:* {{ $serverName }}
+- *Server ID:* {{ $serverId }}
+- **ISP:** {{ $isp }}
+- *Ping:* {{ $ping }}
+- *Download:* {{ $download }}
+- *Upload:* {{ $upload }}
+- **Packet Loss:** {{ $packetLoss }}**%**
+- **Ookla Speedtest:** {{ $speedtest_url }}
+- **URL:** {{ $url }}

--- a/resources/views/wecom/speedtest-threshold.blade.php
+++ b/resources/views/wecom/speedtest-threshold.blade.php
@@ -1,0 +1,9 @@
+**Speedtest Threshold Breached - #{{ $id }}**
+
+A new speedtest on **{{ config('app.name') }}** was completed using **{{ $service }}** on **{{ $isp }}** but a threshold was breached.
+
+@foreach ($metrics as $item)
+- **{{ $item['name'] }}** {{ $item['threshold'] }}: {{ $item['value'] }}
+@endforeach
+- **Ookla Speedtest:** {{ $speedtest_url }}
+- **URL:** {{ $url }}


### PR DESCRIPTION
## 📃 Description

This PR will add support for DingTalk and WeCom notification channels.

## 📖 Documentation

After this PR is merged I will write the documentation and submit a PR to speedtest-tracker-docs.

## 🪵 Changelog

### ➕ Added

- DingTalk notification channel
- WeCom notification channel

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.

### Speedtest Completed of DingTalk

<img width="429" alt="image" src="https://github.com/user-attachments/assets/57eb7aa3-fa47-471f-965d-2444f4bdf6e3" />

### Speedtest Threshold Breached of DingTalk

<img width="428" alt="image" src="https://github.com/user-attachments/assets/90cdeb4e-cde7-4a1f-954d-51a214395ccf" />

### Speedtest Completed of WeCom

<img width="402" alt="image" src="https://github.com/user-attachments/assets/ecee09a7-1660-41f1-9125-90246e86807d" />

### Speedtest Threshold Breached of WeCom

<img width="402" alt="image" src="https://github.com/user-attachments/assets/124163fe-702f-467a-9cf1-330d29aa1681" />
