### PR TITLE
Added allowed IPs

### DIFF
--- a/app/Http/Middleware/AllowedIpAddressesMiddleware.php
+++ b/app/Http/Middleware/AllowedIpAddressesMiddleware.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AllowedIpAddressesMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (blank(config('speedtest.allowed_ips'))) {
+            return $next($request);
+        }
+
+        $allowedIps = explode(',', config('speedtest.allowed_ips'));
+
+        return in_array($request->ip(), $allowedIps)
+            ? $next($request)
+            : abort(403);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,10 @@ return Application::configure(basePath: dirname(__DIR__))
             'public-dashboard' => App\Http\Middleware\PublicDashboard::class,
         ]);
 
+        $middleware->prependToGroup('api', [
+            App\Http\Middleware\AllowedIpAddressesMiddleware::class,
+        ]);
+
         $middleware->prependToGroup('web', [
             App\Http\Middleware\AllowedIpAddressesMiddleware::class,
         ]);

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -19,6 +19,10 @@ return Application::configure(basePath: dirname(__DIR__))
             'public-dashboard' => App\Http\Middleware\PublicDashboard::class,
         ]);
 
+        $middleware->prependToGroup('web', [
+            App\Http\Middleware\AllowedIpAddressesMiddleware::class,
+        ]);
+
         $middleware->redirectGuestsTo(fn () => route('filament.admin.auth.login'));
         $middleware->redirectUsersTo(AppServiceProvider::HOME);
 

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -11,6 +11,8 @@ return [
     /**
      * General settings.
      */
+    'allowed_ips' => env('ALLOWED_IPS'),
+
     'content_width' => env('CONTENT_WIDTH', '7xl'),
 
     'prune_results_older_than' => (int) env('PRUNE_RESULTS_OLDER_THAN', 0),


### PR DESCRIPTION
## 📃 Description

This PR adds allowed IPs middleware to the `api` and `web` groups and will prevent any requests if any IP addresses are specified. `ALLOWED_IPS` can be set to an IP address (`127.0.0.1`) or a list of IP addresses (`127.0.0.1,127.0.0.2`).

- closes #2159 

## 📖 Documentation

https://docs.speedtest-tracker.dev/getting-started/environment-variables#application

## 🪵 Changelog

### ➕ Added

- `ALLOWED_IPS` to allow only certain IP addresses from accessing the application.
