### PR TITLE
Run Speedtests from the API

### DIFF
--- a/app/Actions/Ookla/StartSpeedtest.php
+++ b/app/Actions/Ookla/StartSpeedtest.php
@@ -4,7 +4,7 @@ namespace App\Actions\Ookla;
 
 use App\Enums\ResultService;
 use App\Enums\ResultStatus;
-use App\Events\SpeedtestStarted;
+use App\Events\SpeedtestWaiting;
 use App\Jobs\Ookla\ProcessSpeedtestBatch;
 use App\Models\Result;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -13,12 +13,12 @@ class StartSpeedtest
 {
     use AsAction;
 
-    public function handle(bool $scheduled = false, ?int $serverId = null): void
+    public function handle(bool $scheduled = false, ?int $serverId = null): Result
     {
         $result = Result::create([
             'data->server->id' => $serverId,
             'service' => ResultService::Ookla,
-            'status' => ResultStatus::Started,
+            'status' => ResultStatus::Waiting,
             'scheduled' => $scheduled,
         ]);
 
@@ -26,6 +26,8 @@ class StartSpeedtest
             result: $result,
         );
 
-        SpeedtestStarted::dispatch($result);
+        SpeedtestWaiting::dispatch($result);
+
+        return $result;
     }
 }

--- a/app/Enums/ResultStatus.php
+++ b/app/Enums/ResultStatus.php
@@ -15,6 +15,7 @@ enum ResultStatus: string implements HasColor, HasLabel
     case Running = 'running';
     case Started = 'started';
     case Skipped = 'skipped';
+    case Waiting = 'waiting';
 
     public function getColor(): ?string
     {
@@ -26,6 +27,7 @@ enum ResultStatus: string implements HasColor, HasLabel
             self::Running => 'info',
             self::Started => 'info',
             self::Skipped => 'gray',
+            self::Waiting => 'info',
         };
     }
 

--- a/app/Events/SpeedtestWaiting.php
+++ b/app/Events/SpeedtestWaiting.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Result;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class SpeedtestWaiting
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+}

--- a/app/Filament/Pages/ApiTokens.php
+++ b/app/Filament/Pages/ApiTokens.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages;
 
 use Carbon\Carbon;
+use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
@@ -73,6 +74,16 @@ class ApiTokens extends Page implements HasForms, HasInfolists, HasTable
                             ->maxLength('100')
                             ->required()
                             ->autocomplete(false),
+                        CheckboxList::make('abilities')
+                            ->options([
+                                'results:read' => 'Read results',
+                                'speedtests:run' => 'Run speedtest',
+                            ])
+                            ->descriptions([
+                                'results:read' => 'Allow this token to read results.',
+                                'speedtests:run' => 'Allow this token to run speedtests.',
+                            ])
+                            ->bulkToggleable(),
                         DateTimePicker::make('token_expires_at')
                             ->label('Expires at')
                             ->nullable()
@@ -81,6 +92,7 @@ class ApiTokens extends Page implements HasForms, HasInfolists, HasTable
                     ->action(function (array $data) {
                         $token = Auth::user()->createToken(
                             name: $data['token_name'],
+                            abilities: $data['abilities'],
                             expiresAt: $data['token_expires_at'] ? Carbon::parse($data['token_expires_at']) : null,
                         );
 
@@ -96,6 +108,8 @@ class ApiTokens extends Page implements HasForms, HasInfolists, HasTable
                     ->sortable(),
                 TextColumn::make('name')
                     ->searchable(),
+                TextColumn::make('abilities')
+                    ->badge(),
                 TextColumn::make('last_used_at')
                     ->alignEnd()
                     ->dateTime()

--- a/app/Filament/Pages/ApiTokens.php
+++ b/app/Filament/Pages/ApiTokens.php
@@ -103,13 +103,14 @@ class ApiTokens extends Page implements HasForms, HasInfolists, HasTable
                     ->modalWidth(MaxWidth::ExtraLarge),
             ])
             ->columns([
-                TextColumn::make('id')
-                    ->label('ID')
-                    ->sortable(),
                 TextColumn::make('name')
                     ->searchable(),
                 TextColumn::make('abilities')
                     ->badge(),
+                TextColumn::make('created_at')
+                    ->alignEnd()
+                    ->dateTime()
+                    ->sortable(),
                 TextColumn::make('last_used_at')
                     ->alignEnd()
                     ->dateTime()

--- a/app/Http/Controllers/Api/V1/ApiController.php
+++ b/app/Http/Controllers/Api/V1/ApiController.php
@@ -13,6 +13,7 @@ abstract class ApiController
      * Send a response.
      *
      * @param  mixed  $data
+     * @param  array  $filters
      * @param  string  $message
      * @param  int  $code
      * @return \Illuminate\Http\JsonResponse
@@ -29,7 +30,10 @@ abstract class ApiController
             $response['message'] = $message;
         }
 
-        return response()->json($response, $code);
+        return response()->json(
+            data: $response,
+            status: $code,
+        );
     }
 
     /**
@@ -44,10 +48,15 @@ abstract class ApiController
     {
         Log::info($e);
 
+        $response = [
+            'message' => $e->getMessage(),
+        ];
+
         throw new HttpResponseException(
-            response: response()->json([
-                'message' => $e->getMessage(),
-            ], $code)
+            response: response()->json(
+                data: $response,
+                status: $code,
+            ),
         );
     }
 }

--- a/app/Http/Controllers/Api/V1/RunSpeedtest.php
+++ b/app/Http/Controllers/Api/V1/RunSpeedtest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Actions\Ookla\StartSpeedtest;
+use App\Http\Resources\V1\ResultResource;
+use Illuminate\Http\Request;
+
+class RunSpeedtest extends ApiController
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request)
+    {
+        if ($request->user()->tokenCant('speedtests:run')) {
+            return self::sendResponse(
+                data: null,
+                message: 'You do not have permission to run speedtests.',
+                code: 403,
+            );
+        }
+
+        $validated = $request->validate([
+            'server_id' => ['sometimes', 'integer'],
+        ]);
+
+        $result = StartSpeedtest::run(
+            serverId: $validated['server_id'] ?? null,
+        );
+
+        return self::sendResponse(
+            data: new ResultResource($result),
+            message: 'Speedtest added to the queue.',
+        );
+    }
+}

--- a/app/Http/Controllers/Api/V1/RunSpeedtest.php
+++ b/app/Http/Controllers/Api/V1/RunSpeedtest.php
@@ -5,25 +5,51 @@ namespace App\Http\Controllers\Api\V1;
 use App\Actions\Ookla\StartSpeedtest;
 use App\Http\Resources\V1\ResultResource;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Validator;
+use OpenApi\Attributes as OA;
 
 class RunSpeedtest extends ApiController
 {
-    /**
-     * Handle the incoming request.
-     */
+    #[OA\Post(
+        path: '/api/v1/speedtests/run',
+        description: 'Run a new Ookla speedtest. Optionally provide a server_id.',
+        parameters: [
+            new OA\Parameter(
+                name: 'server_id',
+                in: 'query',
+                required: false,
+                schema: new OA\Schema(type: 'integer'),
+                description: 'Optional Ookla speedtest server ID'
+            ),
+        ],
+        responses: [
+            new OA\Response(response: Response::HTTP_CREATED, description: 'Created'),
+            new OA\Response(response: Response::HTTP_FORBIDDEN, description: 'Forbidden'),
+            new OA\Response(response: Response::HTTP_UNPROCESSABLE_ENTITY, description: 'Validation error'),
+        ]
+    )]
     public function __invoke(Request $request)
     {
         if ($request->user()->tokenCant('speedtests:run')) {
             return self::sendResponse(
                 data: null,
                 message: 'You do not have permission to run speedtests.',
-                code: 403,
+                code: Response::HTTP_FORBIDDEN,
             );
         }
 
-        $validated = $request->validate([
-            'server_id' => ['sometimes', 'integer'],
+        $validator = Validator::make($request->all(), [
+            'server_id' => 'sometimes|integer',
         ]);
+
+        if ($validator->fails()) {
+            return ApiController::sendResponse(
+                data: $validator->errors(),
+                message: 'Validation failed.',
+                code: Response::HTTP_UNPROCESSABLE_ENTITY,
+            );
+        }
 
         $result = StartSpeedtest::run(
             serverId: $validated['server_id'] ?? null,
@@ -32,6 +58,7 @@ class RunSpeedtest extends ApiController
         return self::sendResponse(
             data: new ResultResource($result),
             message: 'Speedtest added to the queue.',
+            code: Response::HTTP_CREATED,
         );
     }
 }

--- a/app/Jobs/Ookla/ProcessSpeedtestBatch.php
+++ b/app/Jobs/Ookla/ProcessSpeedtestBatch.php
@@ -29,6 +29,7 @@ class ProcessSpeedtestBatch implements ShouldQueue
     {
         Bus::batch([
             [
+                new StartSpeedtestJob($this->result),
                 new CheckForInternetConnectionJob($this->result),
                 new SkipSpeedtestJob($this->result),
                 new SelectSpeedtestServerJob($this->result),

--- a/app/Jobs/Ookla/StartSpeedtestJob.php
+++ b/app/Jobs/Ookla/StartSpeedtestJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Ookla;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestStarted;
+use App\Models\Result;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+
+class StartSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->result->update([
+            'status' => ResultStatus::Started,
+        ]);
+
+        SpeedtestStarted::dispatch($this->result);
+    }
+}

--- a/database/migrations/2025_05_19_160458_reset_existing_api_token_abilities.php
+++ b/database/migrations/2025_05_19_160458_reset_existing_api_token_abilities.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Laravel\Sanctum\PersonalAccessToken;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        PersonalAccessToken::all()->each(function (PersonalAccessToken $token) {
+            $token->abilities = [
+                'results:read',
+            ];
+
+            $token->save();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -17,7 +17,7 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
     Route::get('/results/{result}', ShowResult::class)
         ->name('results.show');
 
-    Route::get('/speedtests/run', RunSpeedtest::class)
+    Route::post('/speedtests/run', RunSpeedtest::class)
         ->name('speedtests.run');
 
     Route::get('/stats', Stats::class)

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Api\V1\LatestResult;
 use App\Http\Controllers\Api\V1\ListResults;
+use App\Http\Controllers\Api\V1\RunSpeedtest;
 use App\Http\Controllers\Api\V1\ShowResult;
 use App\Http\Controllers\Api\V1\Stats;
 use Illuminate\Support\Facades\Route;
@@ -15,6 +16,9 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
 
     Route::get('/results/{result}', ShowResult::class)
         ->name('results.show');
+
+    Route::get('/speedtests/run', RunSpeedtest::class)
+        ->name('speedtests.run');
 
     Route::get('/stats', Stats::class)
         ->name('stats');


### PR DESCRIPTION
## 📃 Description

This PR introduces a new `POST` request endpoint `/api/v1/speedtests/run` to run a speedtest via the API. The API will respond with the result ID and a new status of "waiting".

This PR expands on the work started in #2201.

- closes #1047 

## 📖 Documentation

https://docs.speedtest-tracker.dev/api/v1#run-speedtest

## 🪵 Changelog

### ➕ Added

- API abilities for `results:read` and `speedtests:run`, on deployment/update all existing token will be scoped to the `results:read` ability only. To use `speedtests:run` a new API token needs to be created.
- "waiting" result status for when a speedtest was created in the database but has not been picked up by a queue worker.

### ✏️ Changed

- removed `ID` column from API tokens list and added `created_at` date.
