### PR TITLE
[Feature] Add Ookla Server List to API

### DIFF
--- a/app/Filament/Pages/ApiTokens.php
+++ b/app/Filament/Pages/ApiTokens.php
@@ -78,10 +78,12 @@ class ApiTokens extends Page implements HasForms, HasInfolists, HasTable
                             ->options([
                                 'results:read' => 'Read results',
                                 'speedtests:run' => 'Run speedtest',
+                                'ookla:list-servers' => 'List servers',
                             ])
                             ->descriptions([
                                 'results:read' => 'Allow this token to read results.',
                                 'speedtests:run' => 'Allow this token to run speedtests.',
+                                'ookla:list-servers' => 'Allow this token to list server.',
                             ])
                             ->bulkToggleable(),
                         DateTimePicker::make('token_expires_at')

--- a/app/Http/Controllers/Api/V1/ListSpeedtestServers.php
+++ b/app/Http/Controllers/Api/V1/ListSpeedtestServers.php
@@ -10,7 +10,7 @@ use OpenApi\Attributes as OA;
 class ListSpeedtestServers extends ApiController
 {
     #[OA\Get(
-        path: '/api/v1/speedtests/servers',
+        path: '/api/v1/ookla/list-servers',
         description: 'Get a list of available Ookla speedtest servers.',
         responses: [
             new OA\Response(response: Response::HTTP_OK, description: 'OK'),
@@ -19,7 +19,7 @@ class ListSpeedtestServers extends ApiController
     )]
     public function __invoke(Request $request)
     {
-        if ($request->user()->tokenCant('speedtests:run')) {
+        if ($request->user()->tokenCant('ookla:list-servers')) {
             return self::sendResponse(
                 data: null,
                 message: 'You do not have permission to view speedtest servers.',

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -21,8 +21,8 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
     Route::post('/speedtests/run', RunSpeedtest::class)
         ->name('speedtests.run');
 
-    Route::get('/speedtests/servers', ListSpeedtestServers::class)
-        ->name('speedtests.servers');
+    Route::get('/ookla/list-servers', ListSpeedtestServers::class)
+        ->name('ookla.list-servers');
 
     Route::get('/stats', Stats::class)
         ->name('stats');


### PR DESCRIPTION
## 📃 Description

This PR adds a server list to the API /`api/v1/speedtests/servers`. 

Response;

```
{
    "data": {
        "52365": "Odido (Amsterdam, 52365)",
        "55633": "Odido (Arnhem, 55633)",
        "52857": "Delta Fiber Nederland (Rotterdam, 52857)",
        "6554": "WorldStream B.V. (Naaldwijk, 6554)",
        "26476": "Glasnet (Den Haag, 26476)",
        "3242": "ColoCenter bv (Zoetermeer, 3242)",
        "35392": "Mr_joep (Breda, 35392)",
        "32582": "VodafoneZiggo (Schiphol, 32582)",
        "61186": "KPN B.V. (Amstelveen, 61186)",
        "23094": "31173 Services AB (Amsterdam, 23094)",
        "13157": "AVUR AS (Amsterdam, 13157)",
        "13764": "Eranium B.V. (Amsterdam, 13764)",
        "31337": "Qonnected B.V. (Amsterdam, 31337)",
        "46712": "Hivelocity (Amsterdam, 46712)",
        "35058": "Clouvider Ltd (Amsterdam, 35058)",
        "11611": "KamaTera, Inc. (Amsterdam, 11611)",
        "9913": "fdcservers.net (Amsterdam, 9913)",
        "50720": "ServerRoom.net (Amsterdam, 50720)",
        "33814": "dstny (Amsterdam, 33814)",
        "45549": "NewsXS B.V. (Amsterdam, 45549)"
    },
    "message": "Speedtest servers fetched successfully."
}

```
## 📖 Documentation

https://github.com/alexjustesen/speedtest-tracker-docs/pull/75

## 🪵 Changelog

### ➕ Added

- Add the ability to request the Ookla server list

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.
