### PR TITLE
[Chore] Lock inactive issues and PRs

### DIFF
--- a/.github/workflows/inactivity-actions.yml
+++ b/.github/workflows/inactivity-actions.yml
@@ -11,15 +11,16 @@ permissions:
 
 jobs:
   lock-inactive:
-    name: Lock Inactive Issues and PRs
-    runs-on: ubuntu-latest
+    name: Lock Inactive Issues
+    runs-on: ubuntu-24.04
     steps:
       - uses: klaasnicolaas/action-inactivity-lock@v1.1.3
         id: lock
         with:
           days-inactive-issues: 14
           lock-reason-issues: ""
-          days-inactive-prs: 120
+          # Action can not skip PRs, set it to 100 years to cover it.
+          days-inactive-prs: 36524
           lock-reason-prs: ""
       - name: 🔍 Display locked issues
         run: |

--- a/.github/workflows/inactivity-actions.yml
+++ b/.github/workflows/inactivity-actions.yml
@@ -1,24 +1,40 @@
-name: 'Close stale issues'
+name: 'Issue and PR Maintenance'
 
 on:
   schedule:
-    - cron: '0 10 * * *'  # Runs daily at 10:00 AM UTC
+    - cron: '0 0 * * *'   # runs at midnight UTC
   workflow_dispatch:
 
 permissions:
   issues: write
+  pull-requests: write
 
 jobs:
-  manage-stale-issues:
-    runs-on: ubuntu-24.04
+  lock-inactive:
+    name: Lock Inactive Issues and PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: klaasnicolaas/action-inactivity-lock@v1.1.3
+        id: lock
+        with:
+          days-inactive-issues: 14
+          lock-reason-issues: ""
+          days-inactive-prs: 120
+          lock-reason-prs: ""
+      - name: 🔍 Display locked issues
+        run: |
+          echo "Locked issues: $(echo '${{ steps.lock.outputs.locked-issues }}' | jq)"
 
+  close-stale:
+    name: Close Stale Issues
+    runs-on: ubuntu-24.04
     steps:
       - name: Close Stale Issues
         uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-          # Stale messaging
+          # Messaging
           stale-issue-message: >
             👋 This issue has been automatically marked as stale due to inactivity.
             If this issue is still relevant, please comment to keep it open.
@@ -32,17 +48,15 @@ jobs:
           days-before-issue-stale: 14
           days-before-issue-close: 7
 
-          # Label management
+          # Labels
           stale-issue-label: 'stale'
           remove-stale-when-updated: true
-
-          # Targeting only `question`-labeled issues
           only-issue-labels: 'question'
           exempt-issue-labels: >
             bug, chore, confirmed, dependencies, help wanted,
             documentation, duplicate, feature, good first issue,
             needs review, wontfix
 
-          # Skip assigned or milestone-tracked issues
+          # Exemptions
           exempt-assignees: true
           exempt-milestones: true


### PR DESCRIPTION
📃 Description

This pull request introduces a unified GitHub Actions workflow to handle repository hygiene tasks, specifically locking inactive issues/PRs and closing stale issues. It replaces previously separate workflows with a single, maintainable issue_pr_maintenance.yml. This prevents people from commenting on old issues and send notifications to others.

> action-inactivity-lock is not able to exclude PRs, set it to 120 to give it enough time before locking

📖 Documentation

No documentation changes required for this PR.

🪵 Changelog

➕ Added
- New issue_pr_maintenance.yml GitHub Actions workflow
- Locking job using klaasnicolaas/action-inactivity-lock@v1.1.3
- Closing stale question issues using actions/stale@v9

📷 Screenshots

Not applicable – this PR does not include UI changes.
