### PR TITLE
[Bug] Fix missing Get and type in BuildPointData

### DIFF
--- a/app/Actions/Influxdb/v2/BuildPointData.php
+++ b/app/Actions/Influxdb/v2/BuildPointData.php
@@ -50,8 +50,8 @@ class BuildPointData
             ->addField('upload_latency_avg', Number::castToType(Arr::get($result->data, 'upload.latency.iqm'), 'float'))
             ->addField('upload_latency_high', Number::castToType(Arr::get($result->data, 'upload.latency.high'), 'float'))
             ->addField('upload_latency_low', Number::castToType(Arr::get($result->data, 'upload.latency.low'), 'float'))
-            ->addField('downloaded_bytes', Number::castToType($result->data, 'downloaded_bytes', 'int'))
-            ->addField('uploaded_bytes', Number::castToType($result->data, 'uploaded_bytes', 'int'))
+            ->addField('downloaded_bytes', Number::castToType(Arr::get($result->data, 'downloaded_bytes'), 'float'))
+            ->addField('uploaded_bytes', Number::castToType(Arr::get($result->data, 'uploaded_bytes'), 'float'))
             ->addField('packet_loss', Number::castToType(Arr::get($result->data, 'packetLoss'), 'float'))
             ->addField('log_message', Arr::get($result->data, 'message'));
 


### PR DESCRIPTION
## 📃 Description

This PR fixes the Influxdb BuildPointData causing the export to fail, after https://github.com/alexjustesen/speedtest-tracker/pull/2256

Fixes https://github.com/alexjustesen/speedtest-tracker/issues/2270

## 🪵 Changelog

### 🔧 Fixed

- Add the missing `Arr::get` to `downloaded_bytes` and `uploaded_bytes`
- Change type to `float` as well 
