### PR TITLE
Add download and upload bytes

### DIFF
--- a/app/Actions/Influxdb/v2/BuildPointData.php
+++ b/app/Actions/Influxdb/v2/BuildPointData.php
@@ -50,8 +50,8 @@ class BuildPointData
             ->addField('upload_latency_avg', Number::castToType(Arr::get($result->data, 'upload.latency.iqm'), 'float'))
             ->addField('upload_latency_high', Number::castToType(Arr::get($result->data, 'upload.latency.high'), 'float'))
             ->addField('upload_latency_low', Number::castToType(Arr::get($result->data, 'upload.latency.low'), 'float'))
-            ->addField('downloaded_bytes', Number::castToType(Arr::get($result->data, 'downloaded_bytes'), 'float'))
-            ->addField('uploaded_bytes', Number::castToType(Arr::get($result->data, 'uploaded_bytes'), 'float'))
+            ->addField('download_bytes', Number::castToType($result->data, 'download_bytes', 'float')) // TODO: this should be an integer in the next version.
+            ->addField('upload_bytes', Number::castToType($result->data, 'upload_bytes', 'float')) // TODO: this should be an integer in the next version.
             ->addField('packet_loss', Number::castToType(Arr::get($result->data, 'packetLoss'), 'float'))
             ->addField('log_message', Arr::get($result->data, 'message'));
 

--- a/app/Http/Resources/V1/ResultResource.php
+++ b/app/Http/Resources/V1/ResultResource.php
@@ -5,6 +5,7 @@ namespace App\Http\Resources\V1;
 use App\Helpers\Bitrate;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Number;
 
 class ResultResource extends JsonResource
 {
@@ -25,6 +26,10 @@ class ResultResource extends JsonResource
             'upload_bits' => $this->when($this->upload, fn (): int|float => Bitrate::bytesToBits($this->upload)),
             'download_bits_human' => $this->when($this->download, fn (): string => Bitrate::formatBits(Bitrate::bytesToBits($this->download)).'ps'),
             'upload_bits_human' => $this->when($this->upload, fn (): string => Bitrate::formatBits(Bitrate::bytesToBits($this->upload)).'ps'),
+            'download_bytes' => $this->download_bytes,
+            'upload_bytes' => $this->upload_bytes,
+            'download_bytes_human' => $this->when($this->download_bytes, fn (): string => Number::fileSize($this->download_bytes)),
+            'upload_bytes_human' => $this->when($this->upload_bytes, fn (): string => Number::fileSize($this->upload_bytes)),
             'benchmarks' => $this->benchmarks,
             'healthy' => $this->healthy,
             'status' => $this->status,

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -90,6 +90,8 @@ class RunSpeedtestJob implements ShouldQueue
             'ping' => Arr::get($output, 'ping.latency'),
             'download' => Arr::get($output, 'download.bandwidth'),
             'upload' => Arr::get($output, 'upload.bandwidth'),
+            'download_bytes' => Arr::get($output, 'download.bytes'),
+            'upload_bytes' => Arr::get($output, 'upload.bytes'),
             'data' => $output,
         ]);
     }

--- a/database/factories/ResultFactory.php
+++ b/database/factories/ResultFactory.php
@@ -45,6 +45,8 @@ class ResultFactory extends Factory
             'ping' => Arr::get($output, 'ping.latency'),
             'download' => Arr::get($output, 'download.bandwidth'),
             'upload' => Arr::get($output, 'upload.bandwidth'),
+            'download_bytes' => Arr::get($output, 'download.bytes'),
+            'upload_bytes' => Arr::get($output, 'upload.bytes'),
             'data' => $output,
             'status' => ResultStatus::Completed,
             'scheduled' => false,

--- a/database/migrations/2025_07_31_225208_add_bytes_to_results_table.php
+++ b/database/migrations/2025_07_31_225208_add_bytes_to_results_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('results', function (Blueprint $table) {
+            $table->after('upload', function (Blueprint $table) {
+                $table->unsignedBigInteger('download_bytes')->nullable();
+                $table->unsignedBigInteger('upload_bytes')->nullable();
+            });
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};


### PR DESCRIPTION
## 📃 Description

This PR adds `download_bytes` and `upload_bytes` to the results table, api response and to the InfluxDB attributes.

## 📖 Documentation

Add a link to the PR for [documentation](https://github.com/alexjustesen/speedtest-tracker-docs) changes.

## 🪵 Changelog

### ➕ Added

- one
- two

### ✏️ Changed

- one
- two

### 🔧 Fixed

- one
- two

### 🗑️ Removed

- one
- two

## 📷 Screenshots

If this PR has any UI/UX changes it's strongly suggested you add screenshots here.
