### PR TITLE
[Chrore] Handle speedtest.net not reachable gracefully. 

### DIFF
--- a/app/Actions/GetOoklaSpeedtestServers.php
+++ b/app/Actions/GetOoklaSpeedtestServers.php
@@ -17,7 +17,15 @@ class GetOoklaSpeedtestServers
      */
     public function handle(): array
     {
-        return collect(self::fetch())->mapWithKeys(function (array $item) {
+        $servers = self::fetch();
+
+        // If the first item is not an array, treat as error or empty
+        if (empty($servers) || ! is_array($servers) || (isset($servers[0]) && ! is_array($servers[0]))) {
+            // Return error message as a single option so user can see the error
+            return ['error' => $servers[0] ?? 'Unable to retrieve servers'];
+        }
+
+        return collect($servers)->mapWithKeys(function (array $item) {
             return [
                 $item['id'] => ($item['sponsor'] ?? 'Unknown').' ('.($item['name'] ?? 'Unknown').', '.$item['id'].')',
             ];


### PR DESCRIPTION
## 📃 Description

When speedtest.net is not reachable the manual speedtests server list fails hard with a server error.  This PR handles the error nicely and shows a friendly users that the server list is not available. 

<img width="662" height="397" alt="Scherm­afbeelding 2025-08-13 om 18 28 18" src="https://github.com/user-attachments/assets/5fc05ba4-3569-4237-8f91-8b55c49d0f78" />

closes #2311