### PR TITLE
Add default chart range

### DIFF
--- a/app/Filament/Widgets/Concerns/HasChartFilters.php
+++ b/app/Filament/Widgets/Concerns/HasChartFilters.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Filament\Widgets\Concerns;
+
+trait HasChartFilters
+{
+    protected function getFilters(): ?array
+    {
+        return [
+            '24h' => 'Last 24 hours',
+            'week' => 'Last 7 days',
+            'month' => 'Last 30 days',
+        ];
+    }
+}

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
@@ -10,6 +11,8 @@ use Filament\Widgets\ChartWidget;
 
 class RecentDownloadChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Download (Mbps)';
 
     protected int|string|array $columnSpan = 'full';
@@ -20,26 +23,9 @@ class RecentDownloadChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -3,11 +3,14 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadLatencyChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Download Latency';
 
     protected int|string|array $columnSpan = 'full';
@@ -18,26 +21,9 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -3,11 +3,14 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
 
 class RecentJitterChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Jitter';
 
     protected int|string|array $columnSpan = 'full';
@@ -18,26 +21,9 @@ class RecentJitterChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -3,12 +3,15 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
 
 class RecentPingChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Ping (ms)';
 
     protected int|string|array $columnSpan = 'full';
@@ -19,26 +22,9 @@ class RecentPingChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
@@ -10,6 +11,8 @@ use Filament\Widgets\ChartWidget;
 
 class RecentUploadChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Upload (Mbps)';
 
     protected int|string|array $columnSpan = 'full';
@@ -20,26 +23,9 @@ class RecentUploadChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -3,11 +3,14 @@
 namespace App\Filament\Widgets;
 
 use App\Enums\ResultStatus;
+use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadLatencyChartWidget extends ChartWidget
 {
+    use HasChartFilters;
+
     protected static ?string $heading = 'Upload Latency';
 
     protected int|string|array $columnSpan = 'full';
@@ -18,26 +21,9 @@ class RecentUploadLatencyChartWidget extends ChartWidget
 
     public ?string $filter = null;
 
-    protected function getFilters(): ?array
+    public function mount(): void
     {
-        $default = config('speedtest.default_view_range');
-        $filters = [
-            $default => 'Default (' . ucfirst($default) . ')',
-            '24h' => 'Last 24h',
-            'week' => 'Last week',
-            'month' => 'Last month',
-        ];
-
-        // Remove duplicate if default is one of the others
-        $filters = array_unique($filters);
-
-        // Ensure default is first
-        $filters = array_merge(
-            [$default => $filters[$default]],
-            array_diff_key($filters, [$default => null])
-        );
-
-        return $filters;
+        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
     }
 
     protected function getData(): array

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -6,7 +6,6 @@ return [
     /**
      * General settings.
      */
-
     'build_date' => Carbon::parse('2025-10-24'),
 
     'build_version' => 'v1.6.9',
@@ -17,8 +16,7 @@ return [
 
     'public_dashboard' => env('PUBLIC_DASHBOARD', false),
 
-    'default_view_range' => env('DEFAULT_VIEW_RANGE', '24h'),
-
+    'default_chart_range' => env('DEFAULT_CHART_RANGE', '24h'),
 
     /**
      * Speedtest settings.
@@ -33,25 +31,21 @@ return [
 
     'checkinternet_url' => env('SPEEDTEST_CHECKINTERNET_URL', 'https://icanhazip.com'),
 
-
     /**
      * IP filtering settings.
      */
-
     'allowed_ips' => env('ALLOWED_IPS'),
 
     'skip_ips' => env('SPEEDTEST_SKIP_IPS', ''),
 
-
     /**
      * Threshold settings.
      */
+    'threshold_enabled' => env('THRESHOLD_ENABLED', false),
 
-     'threshold_enabled' => env('THRESHOLD_ENABLED', false),
+    'threshold_download' => env('THRESHOLD_DOWNLOAD', 0),
 
-     'threshold_download' => env('THRESHOLD_DOWNLOAD', 0),
+    'threshold_upload' => env('THRESHOLD_UPLOAD', 0),
 
-     'threshold_upload' => env('THRESHOLD_UPLOAD', 0),
-
-     'threshold_ping' => env('THRESHOLD_PING', 0) ,
+    'threshold_ping' => env('THRESHOLD_PING', 0),
 ];


### PR DESCRIPTION
## 📃 Description

Expanding on the work in #2355 this PR introduces a default chart range that can be set as an environment variable `DEFAULT_CHART_RANGE=24h` where the default is `24h`.

- closes #738 

## 📖 Documentation

[Add a link to the PR for [documentation](https://github.com/alexjustesen/speedtest-tracker-docs) changes.](https://github.com/alexjustesen/speedtest-tracker-docs/pull/88)

## 🪵 Changelog

### ➕ Added

- `DEFAULT_CHART_RANGE` environment variable.

### ✏️ Changed

- Moved `getFilters` method to a trait to reduce duplication
