### PR TITLE
[Bug] Fix Filament panel form namespace error

### DIFF
--- a/resources/views/filament/pages/tools/list-ookla-servers.blade.php
+++ b/resources/views/filament/pages/tools/list-ookla-servers.blade.php
@@ -7,8 +7,8 @@
             </div>
         </div>
     @else
-        <x-filament-panels::form wire:submit.prevent>
+        <form wire:submit.prevent>
             {{ $this->form }}
-        </x-filament-panels::form>
+        </form>
     @endif
 </x-filament-panels::page>


### PR DESCRIPTION
## 📃 Description

`list-ookla-servers.blade` as using `<x-filament-panels::form>` which doesn't exist in Filament 4
In Filament 4, form layout components moved to the filament-schemas namespace
The error only appeared when running `php artisan optimize` (which Docker containers do on startup)

## 📖 Documentation

## 🪵 Changelog

- fixes https://github.com/alexjustesen/speedtest-tracker/issues/2390

