### PR TITLE
bug: fix mails on completed speedtest

### DIFF
--- a/app/Listeners/ProcessCompletedSpeedtest.php
+++ b/app/Listeners/ProcessCompletedSpeedtest.php
@@ -104,7 +104,7 @@ class ProcessCompletedSpeedtest
      */
     private function notifyMailChannels(Result $result): void
     {
-        if (empty($result->dispatched_by) || ! $result->healthy) {
+        if (filled($result->dispatched_by) || ! $result->healthy) {
             return;
         }
 


### PR DESCRIPTION
## 📃 Description

Fixing the mails on completed test. The logic was inverted. It was skipped when `dispatched_by`  was `empty` instead of  `filled` like for wehbooks

### 🔧 Fixed

- closes https://github.com/alexjustesen/speedtest-tracker/issues/2456
