### PR TITLE
bug: fix notifications when not using thresholds 

### DIFF
--- a/app/Listeners/ProcessCompletedSpeedtest.php
+++ b/app/Listeners/ProcessCompletedSpeedtest.php
@@ -55,7 +55,7 @@ class ProcessCompletedSpeedtest
     private function notifyDatabaseChannels(Result $result): void
     {
         // Don't send database notification if dispatched by a user or test is unhealthy.
-        if (filled($result->dispatched_by) || ! $result->healthy) {
+        if (filled($result->dispatched_by) || ! $result->healthy === false) {
             return;
         }
 


### PR DESCRIPTION
## 📃 Description

Fix notifications not being sent when thresholds are not used. 
Please double check the logic :) 

The original code used `! $result->healthy` which means:

When healthy is null, ! null evaluates to true, so it would skip sending notifications ❌
When healthy is false, ! false evaluates to true, so it would skip ✅
When healthy is true, ! true evaluates to false, so it would send ✅

The fix uses `$result->healthy === false `which means:
When healthy is null, it will send notifications ✅
When healthy is false, it will skip ✅
When healthy is true, it will send ✅

closes https://github.com/alexjustesen/speedtest-tracker/issues/2456