### PR TITLE
chore: remove duplicate translation strings

### DIFF
--- a/app/Filament/Pages/Settings/Notification.php
+++ b/app/Filament/Pages/Settings/Notification.php
@@ -83,10 +83,10 @@ class Notification extends SettingsPage
                                             ->columns(1)
                                             ->schema([
                                                 Checkbox::make('database_on_speedtest_run')
-                                                    ->label(__('settings/notifications.database_on_speedtest_run')),
+                                                    ->label(__('settings/notifications.notify_on_every_speedtest_run')),
 
                                                 Checkbox::make('database_on_threshold_failure')
-                                                    ->label(__('settings/notifications.database_on_threshold_failure')),
+                                                    ->label(__('settings/notifications.notify_on_threshold_failures')),
                                             ]),
 
                                         Actions::make([
@@ -115,10 +115,10 @@ class Notification extends SettingsPage
                                             ->columns(1)
                                             ->schema([
                                                 Checkbox::make('mail_on_speedtest_run')
-                                                    ->label(__('settings/notifications.mail_on_speedtest_run')),
+                                                    ->label(__('settings/notifications.notify_on_every_speedtest_run')),
 
                                                 Checkbox::make('mail_on_threshold_failure')
-                                                    ->label(__('settings/notifications.mail_on_threshold_failure')),
+                                                    ->label(__('settings/notifications.notify_on_threshold_failures')),
                                             ]),
 
                                         Repeater::make('mail_recipients')
@@ -173,10 +173,10 @@ class Notification extends SettingsPage
                                             ->columns(1)
                                             ->schema([
                                                 Checkbox::make('webhook_on_speedtest_run')
-                                                    ->label(__('settings/notifications.webhook_on_speedtest_run')),
+                                                    ->label(__('settings/notifications.notify_on_every_speedtest_run')),
 
                                                 Checkbox::make('webhook_on_threshold_failure')
-                                                    ->label(__('settings/notifications.webhook_on_threshold_failure')),
+                                                    ->label(__('settings/notifications.notify_on_threshold_failures')),
                                             ]),
 
                                         Repeater::make('webhook_urls')

--- a/lang/en/settings/notifications.php
+++ b/lang/en/settings/notifications.php
@@ -7,28 +7,22 @@ return [
     // Database notifications
     'database' => 'Database',
     'database_description' => 'Notifications sent to this channel will show up under the 🔔 icon in the header.',
-    'database_on_speedtest_run' => 'Notify on every speedtest run',
-    'database_on_threshold_failure' => 'Notify on threshold failures',
     'test_database_channel' => 'Test database channel',
 
     // Mail notifications
     'mail' => 'Mail',
     'recipients' => 'Recipients',
-    'mail_on_speedtest_run' => 'Notify on every speedtest run',
-    'mail_on_threshold_failure' => 'Notify on threshold failures',
     'test_mail_channel' => 'Test mail channel',
 
     // Webhook
     'webhook' => 'Webhook',
     'webhooks' => 'Webhooks',
-    'webhook_on_speedtest_run' => 'Notify on every speedtest run',
-    'webhook_on_threshold_failure' => 'Notify on threshold failures',
     'test_webhook_channel' => 'Test webhook channel',
     'webhook_hint_description' => 'These are generic webhooks. For payload examples and implementation details, view the documentation.',
 
     // Common notification messages
-    'notify_on_every_speedtest_run' => 'Notify on every speedtest run',
-    'notify_on_threshold_failures' => 'Notify on threshold failures',
+    'notify_on_every_speedtest_run' => 'Notify on every scheduled speedtest run',
+    'notify_on_threshold_failures' => 'Notify on threshold failures for scheduled speedtests',
 
     // Test notification messages
     'test_notifications' => [


### PR DESCRIPTION
## 📃 Description

Removing duplicate translation strings for notifications and emphasise its for scheduled tests.
