### PR TITLE
bug: fix database notifications being sent double

### DIFF
--- a/app/Listeners/ProcessCompletedSpeedtest.php
+++ b/app/Listeners/ProcessCompletedSpeedtest.php
@@ -55,7 +55,7 @@ class ProcessCompletedSpeedtest
     private function notifyDatabaseChannels(Result $result): void
     {
         // Don't send database notification if dispatched by a user or test is unhealthy.
-        if (filled($result->dispatched_by) || ! $result->healthy === false) {
+        if (filled($result->dispatched_by) || $result->healthy === false) {
             return;
         }
 


### PR DESCRIPTION
## 📃 Description

This PR fixes that database notifications where sent for completed and thresholds at the same time. Compared to mail and webhooks. 