### PR TITLE
bug: fix text string prometheus

### DIFF
--- a/app/Filament/Pages/Settings/DataIntegration.php
+++ b/app/Filament/Pages/Settings/DataIntegration.php
@@ -134,7 +134,7 @@ class DataIntegration extends SettingsPage
                             ->schema([
                                 Toggle::make('prometheus_enabled')
                                     ->label(__('settings/data_integration.prometheus_enabled'))
-                                    ->helperText(__('settings/data_integration.influxdb_v2_description'))
+                                    ->helperText(__('settings/data_integration.prometheus_enabled_helper_text'))
                                     ->reactive()
                                     ->columnSpanFull(),
                                 Grid::make(['default' => 1, 'md' => 3])


### PR DESCRIPTION
## 📃 Description

Fix the wrong text string for prometheus. Cause we dont sent data to InfluxDB when you enable Prometheus 😉 

fixes https://github.com/alexjustesen/speedtest-tracker/issues/2481

## 🪵 Changelog

### ✏️ Changed

- replace `settings/data_integration.influxdb_v2_description` with `settings/data_integration.prometheus_enabled_helper_text`

