### PR TITLE
chore: adjust pagination amounts in results table

### DIFF
--- a/app/Filament/Resources/Results/Tables/ResultTable.php
+++ b/app/Filament/Resources/Results/Tables/ResultTable.php
@@ -315,7 +315,7 @@ class ResultTable
                     ->dropdownPlacement('left-start'),
             ])
             ->defaultSort('id', 'desc')
-            ->paginationPageOptions([5, 10, 25, 50, 'all'])
+            ->paginationPageOptions([10, 25, 50])
             ->deferLoading()
             ->poll('60s');
     }


### PR DESCRIPTION
## 📃 Description

Adjust pagination to 10,20,50 for the results table. So the app does not run out memory. 

### 🔧 Fixed

- fixed #2483 
