### PR TITLE
Fix typo: helpertext -> helperText in DataIntegration settings

### DIFF
--- a/app/Filament/Pages/Settings/DataIntegration.php
+++ b/app/Filament/Pages/Settings/DataIntegration.php
@@ -62,7 +62,7 @@ class DataIntegration extends SettingsPage
                             ->schema([
                                 Toggle::make('influxdb_v2_enabled')
                                     ->label(__('settings/data_integration.influxdb_v2_enabled'))
-                                    ->helpertext(__('settings/data_integration.influxdb_v2_description'))
+                                    ->helperText(__('settings/data_integration.influxdb_v2_description'))
                                     ->reactive()
                                     ->columnSpanFull(),
                                 Grid::make(['default' => 1, 'md' => 3])


### PR DESCRIPTION
Fixed incorrect method name `helpertext()` to `helperText()` in the 
InfluxDB v2 enabled toggle field. This typo prevented the helper text
from displaying properly on the Data Integration settings page.