### PR TITLE
Update benchmark status indicators to use check and alert icons

### DIFF
--- a/resources/views/livewire/latest-result-stats.blade.php
+++ b/resources/views/livewire/latest-result-stats.blade.php
@@ -37,12 +37,14 @@
                 @filled($downloadBenchmark)
                     <x-slot name="afterHeader">
                         <span @class([
-                            'inline-flex items-center gap-x-1.5 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
-                            'text-zinc-700 dark:text-zinc-300' => $downloadBenchmarkPassed,
+                            'inline-flex items-center gap-x-1 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
+                            'text-green-500 dark:text-green-400' => $downloadBenchmarkPassed,
                             'text-amber-500 dark:text-amber-400' => ! $downloadBenchmarkPassed,
                         ]) title="Benchmark {{ $downloadBenchmarkPassed ? 'passed' : 'failed' }}">
-                            @if (! $downloadBenchmarkPassed)
-                                <x-tabler-alert-triangle class="size-4" />
+                            @if ($downloadBenchmarkPassed)
+                                <x-tabler-circle-check class="size-4" />
+                            @else
+                                <x-tabler-alert-circle class="size-4" />
                             @endif
                             {{ Arr::get($downloadBenchmark, 'value').' '.str(Arr::get($downloadBenchmark, 'unit'))->title() }}
                         </span>
@@ -74,11 +76,13 @@
                 @filled($uploadBenchmark)
                     <x-slot name="afterHeader">
                         <span @class([
-                            'inline-flex items-center gap-x-1.5 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
-                            'text-zinc-700 dark:text-zinc-300' => $uploadBenchmarkPassed,
+                            'inline-flex items-center gap-x-1 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
+                            'text-green-500 dark:text-green-400' => $uploadBenchmarkPassed,
                             'text-amber-500 dark:text-amber-400' => ! $uploadBenchmarkPassed,
                         ]) title="Benchmark {{ $uploadBenchmarkPassed ? 'passed' : 'failed' }}">
-                            @if (! $uploadBenchmarkPassed)
+                            @if ($uploadBenchmarkPassed)
+                                <x-tabler-circle-check class="size-4" />
+                            @else
                                 <x-tabler-alert-triangle class="size-4" />
                             @endif
                             {{ Arr::get($uploadBenchmark, 'value').' '.str(Arr::get($uploadBenchmark, 'unit'))->title() }}
@@ -111,11 +115,13 @@
                 @filled($pingBenchmark)
                     <x-slot name="afterHeader">
                         <span @class([
-                            'inline-flex items-center gap-x-1.5 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
-                            'text-zinc-700 dark:text-zinc-300' => $pingBenchmarkPassed,
+                            'inline-flex items-center gap-x-1 text-xs font-medium underline decoration-dotted decoration-1 decoration-zinc-500 underline-offset-4',
+                            'text-green-500 dark:text-green-400' => $pingBenchmarkPassed,
                             'text-amber-500 dark:text-amber-400' => ! $pingBenchmarkPassed,
                         ]) title="Benchmark {{ $pingBenchmarkPassed ? 'passed' : 'failed' }}">
-                            @if (! $pingBenchmarkPassed)
+                            @if ($pingBenchmarkPassed)
+                                <x-tabler-circle-check class="size-4" />
+                            @else
                                 <x-tabler-alert-triangle class="size-4" />
                             @endif
                             {{ Arr::get($pingBenchmark, 'value').' '.str(Arr::get($pingBenchmark, 'unit')) }}


### PR DESCRIPTION
## 📃 Description

This PR improves the UI when a benchmark is healthy or unhealthy for a given KPI on the dashboards.

## 📷 Screenshots

<img width="1232" height="229" alt="image" src="https://github.com/user-attachments/assets/ca8a2adc-4d19-4988-8a50-45ca4117c505" />
