### PR TITLE
chore: round ping value to two decimal places in latest result stats

### DIFF
--- a/resources/views/livewire/latest-result-stats.blade.php
+++ b/resources/views/livewire/latest-result-stats.blade.php
@@ -130,7 +130,7 @@
                 @endfilled
 
                 <p class="flex items-baseline gap-x-2">
-                    <span class="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{{ $this->latestResult?->ping }}</span>
+                    <span class="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{{ round($this->latestResult?->ping, 2) }}</span>
                     <span class="text-sm text-zinc-600 dark:text-zinc-400">ms</span>
                 </p>
             </x-filament::section>


### PR DESCRIPTION
Round ping value to two decimal places in latest result stats
