### PR TITLE
update external IP fetching logic to handle failures

### DIFF
--- a/app/Actions/GetExternalIpAddress.php
+++ b/app/Actions/GetExternalIpAddress.php
@@ -12,18 +12,28 @@ class GetExternalIpAddress
 {
     use AsAction;
 
-    public function handle(): bool|string
+    public function handle(?string $url = null): array
     {
+        $url = $url ?? config('speedtest.preflight.get_external_ip_url');
+
         try {
             $response = Http::retry(3, 100)
                 ->timeout(5)
-                ->get(url: 'https://icanhazip.com/');
+                ->get(url: $url);
         } catch (Throwable $e) {
-            Log::error('Failed to fetch external IP address.', [$e->getMessage()]);
+            $message = sprintf('Failed to fetch external IP address from "%s". See the logs for more details.', $url);
 
-            return false;
+            Log::error($message, [$e->getMessage()]);
+
+            return [
+                'ok' => false,
+                'body' => $message,
+            ];
         }
 
-        return Str::trim($response->body());
+        return [
+            'ok' => $response->ok(),
+            'body' => Str::of($response->body())->trim()->toString(),
+        ];
     }
 }

--- a/app/Jobs/Ookla/SkipSpeedtestJob.php
+++ b/app/Jobs/Ookla/SkipSpeedtestJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\Ookla;
 
 use App\Actions\GetExternalIpAddress;
 use App\Enums\ResultStatus;
+use App\Events\SpeedtestFailed;
 use App\Events\SpeedtestSkipped;
 use App\Helpers\Network;
 use App\Models\Result;
@@ -47,8 +48,23 @@ class SkipSpeedtestJob implements ShouldQueue
 
         $externalIp = GetExternalIpAddress::run();
 
+        if ($externalIp['ok'] === false) {
+            $this->result->update([
+                'data->type' => 'log',
+                'data->level' => 'error',
+                'data->message' => $externalIp['body'],
+                'status' => ResultStatus::Failed,
+            ]);
+
+            SpeedtestFailed::dispatch($this->result);
+
+            $this->batch()->cancel();
+
+            return;
+        }
+
         $shouldSkip = $this->shouldSkip(
-            externalIp: $externalIp,
+            externalIp: $externalIp['body'],
         );
 
         if ($shouldSkip === false) {

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -29,7 +29,11 @@ return [
 
     'interface' => env('SPEEDTEST_INTERFACE'),
 
-    'checkinternet_url' => env('SPEEDTEST_CHECKINTERNET_URL', 'https://icanhazip.com'),
+    'preflight' => [
+        'get_external_ip_url' => env('SPEEDTEST_CHECKINTERNET_URL') ?? env('SPEEDTEST_GET_EXTERNAL_IP_URL', 'https://icanhazip.com'),
+    ],
+
+    'checkinternet_url' => env('SPEEDTEST_CHECKINTERNET_URL'), // ! DEPRECATED, use preflight.get_external_ip_url instead
 
     /**
      * IP filtering settings.


### PR DESCRIPTION
## 🪵 Changelog

### ➕ Added

- `SPEEDTEST_GET_EXTERNAL_IP_URL` env. variable, `SPEEDTEST_CHECKINTERNET_URL` is deprecated

### 🔧 Fixed

- handle failures when getting an external IP address
