### PR TITLE
Fix: Notification URLs respect APP_URL in queue contexts (#2596)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -115,6 +115,8 @@ class AppServiceProvider extends ServiceProvider
      */
     protected function forceHttps(): void
     {
+        URL::forceRootUrl(config('app.url'));
+
         if (! app()->environment('local') && config('app.force_https')) {
             URL::forceScheme('https');
         }


### PR DESCRIPTION
## Summary
Fixes notification URLs that were missing port numbers or defaulting to `localhost` instead of using the configured `APP_URL`.

## Problem
When speedtest notifications are sent (via Discord, Slack, Email, etc.), the "view" links generated in those notifications would use `http://localhost/admin/results` instead of the properly configured URL like `http://10.0.0.102:8765/admin/results`.

This issue occurred in **21 files** across all notification channels:
- Discord, Slack, Telegram, Gotify, Ntfy, Pushover, HealthCheck notifications
- Email notifications  
- Webhook test notifications

## Root Cause
Speedtest notifications are sent from queue workers (background jobs), which run in a CLI context without HTTP request information. Laravel's \`url()\` helper couldn't infer the host/port and would fall back to default behavior without \`URL::forceRootUrl()\` being set.

## Solution
Added \`URL::forceRootUrl(config('app.url'))\` to \`AppServiceProvider::forceHttps()\` to ensure Laravel always uses the configured \`APP_URL\` for URL generation, even in CLI/queue contexts.

## Testing
Tested in Docker environment with:
- \`APP_URL=http://10.0.0.102:8765\`
- Verified notification URLs correctly generated with full host and port
- Confirmed works with \`APP_URL=http://localhost:8765\` as well

## Changes
- **File:** \`app/Providers/AppServiceProvider.php\`
- **Line:** 118
- **Change:** Added one line: \`URL::forceRootUrl(config('app.url'));\`

Fixes #2596