### PR TITLE
Chore: Handle APP_URL with subpath correctly

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -45,7 +45,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->defineCustomIfStatements();
         $this->defineGates();
-        $this->forceHttps();
+        $this->configureUrl();
         $this->setApiRateLimit();
         $this->registerNotificationChannels();
 
@@ -111,10 +111,12 @@ class AppServiceProvider extends ServiceProvider
     }
 
     /**
-     * Force https scheme in non-local environments.
+     * Configure URL generation settings.
      */
-    protected function forceHttps(): void
+    protected function configureUrl(): void
     {
+        URL::useOrigin(config('app.url'));
+
         if (! app()->environment('local') && config('app.force_https')) {
             URL::forceScheme('https');
         }

--- a/tests/Feature/UrlGenerationTest.php
+++ b/tests/Feature/UrlGenerationTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Providers\AppServiceProvider;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\URL;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+describe('url generation with subpath', function () {
+    test('route() helper generates URLs with subpath', function () {
+        URL::useOrigin('http://localhost');
+        config()->set('app.url', 'https://myserver.com/speedtest');
+
+        (new AppServiceProvider(app()))->boot();
+
+        $url = route('getting-started');
+
+        expect($url)->toContain('/speedtest/');
+    });
+
+    test('url() helper respects subpath configuration', function () {
+        URL::useOrigin('http://localhost');
+        config()->set('app.url', 'https://myserver.com/speedtest');
+
+        (new AppServiceProvider(app()))->boot();
+
+        $url = url('/');
+
+        expect($url)->toContain('/speedtest');
+    });
+});
+
+describe('url generation without subpath', function () {
+    test('route() helper generates plain path when APP_URL has no subpath', function () {
+        URL::useOrigin('http://localhost');
+        config()->set('app.url', 'https://myserver.com');
+
+        (new AppServiceProvider(app()))->boot();
+
+        $url = route('getting-started');
+
+        expect($url)->not->toContain('/speedtest/');
+    });
+
+    test('url() helper works correctly without subpath', function () {
+        URL::useOrigin('http://localhost');
+        config()->set('app.url', 'https://myserver.com');
+
+        (new AppServiceProvider(app()))->boot();
+
+        $url = url('/');
+
+        expect($url)->not->toContain('/speedtest');
+    });
+});


### PR DESCRIPTION
> [!WARNING]
> If the user does not have the `APP_URL` set after this fix it will redirect them to `http://localhost`

## 📃 Description

This PR makes sure that we handle `APP_URL` with subpaths better. 

closes #2596

Docs Update: https://github.com/alexjustesen/speedtest-tracker-docs/pull/105

## 🪵 Changelog

### ✏️ Changed

- honor the `APP_URL` variable when generating urls inside the application

## ❔ Tests 

This PR was tests with the added test cases. 
As well manual with the following NGINX config 

<details>

<summary>NGINX Config</summary>

```
server {
    listen 80;
    server_name localhost;

    # Main location for subpath
    location /speedtest/ {
        proxy_pass http://speedtest-tracker-laravel.test-1:80/;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-Port $server_port;

        # WebSocket support
        proxy_http_version 1.1;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";

        # Increase timeouts for long-running requests
        proxy_read_timeout 300;
        proxy_connect_timeout 300;
        proxy_send_timeout 300;
    }

    # Redirect root to subpath
    location = / {
        return 301 /speedtest/;
    }
}
```

</details>

Both the in App notifications and in all the requests the correct URL is used. 

<img width="1133" height="499" alt="Scherm­afbeelding 2026-01-05 om 18 03 46" src="https://github.com/user-attachments/assets/e5933ce9-82cf-414f-a7ec-00cf1cac1c11" />
<img width="688" height="325" alt="Scherm­afbeelding 2026-01-05 om 18 02 23" src="https://github.com/user-attachments/assets/86a95ef4-5da0-443a-b1ff-ea33baa24632" />


