### PR TITLE
chore: add missing translation strings

### DIFF
--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -73,6 +73,10 @@ return [
     'healthy' => 'Healthy',
     'not_measured' => 'Not measured',
     'unhealthy' => 'Unhealthy',
+    'last_results' => 'Last results',
+    'total_failed' => 'Total failed tests',
+    'total_complted' => 'Total completed tests',
+    'total' => 'Total',
 
     // Units
     'ms' => 'ms',

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -9,7 +9,7 @@
         <div class="grid grid-cols-1 gap-6">
             <h2 class="flex items-center gap-x-2 text-base md:text-lg font-semibold text-zinc-900 dark:text-zinc-100 col-span-full">
                 <x-tabler-chart-histogram class="size-5" />
-                Metrics
+                {{ __('general.metrics') }}
             </h2>
 
             @livewire(\App\Filament\Widgets\RecentDownloadChartWidget::class)

--- a/resources/views/livewire/latest-result-stats.blade.php
+++ b/resources/views/livewire/latest-result-stats.blade.php
@@ -6,7 +6,7 @@
                     <div>
                         <h2 class="flex items-center gap-x-2 text-base md:text-lg font-semibold text-zinc-900 dark:text-zinc-100">
                             <x-tabler-rocket class="size-5" />
-                            Latest result
+                            {{ __('general.last_results') }}
                         </h2>
 
                         <p class="mt-1 text-sm font-medium text-zinc-600 dark:text-zinc-400">{{ $this->latestResult->created_at->timezone(config('app.display_timezone'))->format(config('app.datetime_format')) }}</p>

--- a/resources/views/livewire/next-speedtest-banner.blade.php
+++ b/resources/views/livewire/next-speedtest-banner.blade.php
@@ -8,7 +8,7 @@
 
                 <div class="ml-3 flex-1">
                     <p class="text-sm text-blue-700 dark:text-blue-300">
-                        Next scheduled test at <span class="font-medium">{{ $this->nextSpeedtest->timezone(config('app.display_timezone'))->format(config('app.datetime_format')) }}</span>.
+                        {{ __('dashboard.next_speedtest_at') }} <span class="font-medium">{{ $this->nextSpeedtest->timezone(config('app.display_timezone'))->format(config('app.datetime_format')) }}</span>.
                     </p>
                 </div>
             </div>

--- a/resources/views/livewire/platform-stats.blade.php
+++ b/resources/views/livewire/platform-stats.blade.php
@@ -25,7 +25,7 @@
 
         <x-filament::section class="col-span-1" icon="tabler-hash" icon-size="md" :compact="true">
             <x-slot name="heading">
-                Total tests
+                {{ __('general.total') }}
             </x-slot>
 
             <p class="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{{ $this->platformStats['total'] }}</p>
@@ -33,7 +33,7 @@
 
         <x-filament::section class="col-span-1" icon="tabler-circle-check" icon-size="md" :compact="true">
             <x-slot name="heading">
-                Total completed tests
+                {{ __('general.total_complted') }}
             </x-slot>
 
             <p class="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{{ $this->platformStats['completed'] }}</p>
@@ -41,7 +41,7 @@
 
         <x-filament::section class="col-span-1" icon="tabler-alert-circle" icon-size="md" :compact="true">
             <x-slot name="heading">
-                Total failed tests
+                {{ __('general.total_failed') }}
             </x-slot>
 
             <p class="text-xl font-semibold tracking-tight text-zinc-900 dark:text-zinc-100">{{ $this->platformStats['failed'] }}</p>


### PR DESCRIPTION
## 📃 Description

Add the missing translation strings for the dashboards. 

source: https://crowdin.com/project/speedtest-tracker/discussions/1

## 🪵 Changelog

### ➕ Added

- translation stings for the dashboard.
