### PR TITLE
Add extended time filters to chart widgets

### DIFF
--- a/app/Filament/Widgets/Concerns/HasChartFilters.php
+++ b/app/Filament/Widgets/Concerns/HasChartFilters.php
@@ -2,6 +2,8 @@
 
 namespace App\Filament\Widgets\Concerns;
 
+use Livewire\Attributes\On;
+
 trait HasChartFilters
 {
     protected function getFilters(): ?array
@@ -10,6 +12,26 @@ trait HasChartFilters
             '24h' => 'Last 24 hours',
             'week' => 'Last 7 days',
             'month' => 'Last 30 days',
+            'mtd' => 'Month to date',
+            '90d' => 'Last 90 days',
+            'ytd' => 'Year to date',
+            '365d' => 'Last 365 days',
+            '5y' => 'Last 5 years',
+            '10y' => 'Last 10 years',
+            'all' => 'All time',
         ];
+    }
+
+    public function updatedFilter($value): void
+    {
+        $this->dispatch('filterChanged', filter: $value);
+    }
+
+    #[On('filterChanged')]
+    public function updateFilterFromEvent($filter): void
+    {
+        if ($this->filter !== $filter) {
+            $this->filter = $filter;
+        }
     }
 }

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -47,6 +47,24 @@ class RecentDownloadChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -45,6 +45,24 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -45,6 +45,24 @@ class RecentJitterChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -46,6 +46,24 @@ class RecentPingChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -47,6 +47,24 @@ class RecentUploadChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -45,6 +45,24 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ->when($this->filter === 'month', function ($query) {
                 $query->where('created_at', '>=', now()->subMonth());
             })
+            ->when($this->filter === 'mtd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfMonth());
+            })
+            ->when($this->filter === '90d', function ($query) {
+                $query->where('created_at', '>=', now()->subDays(90));
+            })
+            ->when($this->filter === 'ytd', function ($query) {
+                $query->where('created_at', '>=', now()->startOfYear());
+            })
+            ->when($this->filter === '365d', function ($query) {
+                $query->where('created_at', '>=', now()->subYear());
+            })
+            ->when($this->filter === '5y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(5));
+            })
+            ->when($this->filter === '10y', function ($query) {
+                $query->where('created_at', '>=', now()->subYears(10));
+            })
             ->orderBy('created_at')
             ->get();
 


### PR DESCRIPTION
## 📃 Description

Introduces new filter options (month to date, last 90 days, year to date, last 365 days, last 5 years, last 10 years, all time) to HasChartFilters and updates all chart widgets to support these filters in their data queries. Also adds Livewire event handling for filter changes to improve interactivity.

## 🪵 Changelog

### ➕ Added

- added more time periods

### ✏️ Changed

- widgets use the same time period when a different time is selected in a different widget.

## 📷 Screenshots

<img width="1680" height="956" alt="Scherm­afbeelding 2026-01-18 om 12 40 58" src="https://github.com/user-attachments/assets/d5239075-f3bb-4df9-a393-4c2a9fae7323" />
