### PR TITLE
bug: fix completed mail

### DIFF
--- a/app/Mail/CompletedSpeedtestMail.php
+++ b/app/Mail/CompletedSpeedtestMail.php
@@ -51,7 +51,7 @@ class CompletedSpeedtestMail extends Mailable implements ShouldQueue
                 'ping' => round($this->result->ping, 2).' ms',
                 'download' => Number::toBitRate(bits: $this->result->download_bits, precision: 2),
                 'upload' => Number::toBitRate(bits: $this->result->upload_bits, precision: 2),
-                'packetLoss' => $result->packet_loss ? round($result->packet_loss, precision: 2) : '',
+                'packetLoss' => $this->result->packet_loss ? round($this->result->packet_loss, precision: 2) : '',
                 'speedtest_url' => $this->result->result_url,
                 'url' => url('/admin/results'),
             ],


### PR DESCRIPTION
## 📃 Description

#2670 caused a bug in the completed mail not being sent

fixes #2690

## 🪵 Changelog

### 🔧 Fixed

- add the missing `this->` to the packet loss data.


