### PR TITLE
[v2] refactor; Prometheus to handle null values and clean up

### DIFF
--- a/BREAKING_CHANGES.md
+++ b/BREAKING_CHANGES.md
@@ -1,0 +1,35 @@
+# Breaking Changes
+
+This document tracks breaking changes that may affect existing users.
+
+## v2.x - Prometheus Metrics Refactor
+
+**Date**: 2026-02-12
+**PR**: #XXXX
+**Impact**: High - Affects all users with Prometheus dashboards/alerts
+
+### Overview
+
+The Prometheus metrics implementation has been significantly refactored to follow Prometheus best practices and naming conventions.
+
+### Metric Name Changes
+
+All speed metrics now have explicit `_per_second` suffix to indicate they are rates:
+
+| Old Metric | New Metric | Migration |
+|------------|------------|-----------|
+| `speedtest_tracker_download_bytes` | `speedtest_tracker_download_bytes_per_second` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_upload_bytes` | `speedtest_tracker_upload_bytes_per_second` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_download_bits` | `speedtest_tracker_download_bits_per_second` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_upload_bits` | `speedtest_tracker_upload_bits_per_second` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_downloaded_bytes` | `speedtest_tracker_test_downloaded_bytes_total` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_uploaded_bytes` | `speedtest_tracker_test_uploaded_bytes_total` | Update all dashboard queries and alert rules |
+| `speedtest_tracker_result_id` | `speedtest_tracker_info` | Update queries - value is now always `1` |
+
+### Label Changes
+
+Some labels have been removed to reduce cardinality:
+
+**Removed Labels**:
+- `server_id` - Use `server_name` instead for filtering
+- `server_country` - Not essential for most queries

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
         "filament/filament": "^5.2",
         "filament/spatie-laravel-settings-plugin": "^5.2",
         "influxdata/influxdb-client-php": "^3.8",
-        "laravel-notification-channels/telegram": "^6.0",
         "laravel/framework": "^12.50.0",
         "laravel/prompts": "^0.3.11",
         "laravel/sanctum": "^4.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1cce055c0f3fe0da6e6b110f9ce6c3e9",
+    "content-hash": "30d545596d328a0b0fd2d5f839b7c8ad",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/tests/Feature/MetricsEndpointTest.php
+++ b/tests/Feature/MetricsEndpointTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Result;
+use App\Services\PrometheusMetricsService;
 use App\Settings\DataIntegrationSettings;
 use Illuminate\Support\Facades\Cache;
 
@@ -26,7 +27,7 @@ describe('metrics endpoint', function () {
         $result = Result::factory()->create();
 
         // Simulate the listener updating metrics
-        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus');
 
@@ -56,7 +57,7 @@ describe('metrics endpoint', function () {
         $result = Result::factory()->create();
 
         // Simulate the listener updating metrics
-        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.100',
@@ -75,7 +76,7 @@ describe('metrics endpoint', function () {
         $result = Result::factory()->create();
 
         // Simulate the listener updating metrics
-        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '10.0.0.1',
@@ -93,7 +94,7 @@ describe('metrics endpoint', function () {
         $result = Result::factory()->create();
 
         // Simulate the listener updating metrics
-        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.150',
@@ -124,7 +125,7 @@ describe('metrics endpoint', function () {
         $result = Result::factory()->create();
 
         // Simulate the listener updating metrics
-        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.50',

--- a/tests/Feature/MetricsEndpointTest.php
+++ b/tests/Feature/MetricsEndpointTest.php
@@ -23,7 +23,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => [],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus');
 
@@ -50,7 +53,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['192.168.1.100', '10.0.0.1'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.100',
@@ -66,7 +72,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => [],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '10.0.0.1',
@@ -81,7 +90,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['192.168.1.0/24'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.150',
@@ -109,7 +121,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['10.0.0.1', '192.168.1.0/24'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(\App\Services\PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.50',


### PR DESCRIPTION
## 📃 Description

This PR significantly improves the Prometheus metrics implementation to follow best practices and standard conventions.

## 🪵 Changelog

### ➕ Added

- Added Standard Metrics
    - ` speedtest_tracker_up` - Exporter health indicator (always 1)
    - `speedtest_tracker_build_info` - Application version metadata
- `registerGaugeIfNotNull` function to skip null metrics. (Was already added and used in fix for v1)
- `BREAKING_CHANGES.md` to track all the breaking changes during v2 development.

### ✏️ Changed

- Cache rendered metrics, only rebuild when speedtest completes
- Improved Metric Naming:
   - `download_bytes` → `download_bytes_per_second` (explicit rate)
   - `upload_bytes` → `upload_bytes_per_second` (explicit rate)
   - `download_bits` → `download_bits_per_second` (explicit rate)
   - `upload_bits` → `upload_bits_per_second` (explicit rate)
   - `downloaded_bytes` → `test_downloaded_bytes_total` (cumulative total)
   - `uploaded_bytes` → `test_uploaded_bytes_total` (cumulative total)

### 🗑️ Removed

- Removed `server_id` label
- Removed `server_country` label


