### PR TITLE
[v2] chore: use same url for ping and http check

### DIFF
--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -82,7 +82,7 @@ class CheckForInternetConnectionJob implements ShouldQueue
      */
     protected function httpFallbackSucceeds(): bool
     {
-        $url = config('speedtest.preflight.external_ip_url');
+        $url = config('speedtest.preflight.internet_check_hostname');
 
         try {
             $response = Http::retry(3, 100)


### PR DESCRIPTION
## 📃 Description

Make sure the same url is used for the ping and HTP check.

## 🪵 Changelog

### ✏️ Changed

- change `speedtest.preflight.external_ip_url` to `speedtest.preflight.internet_check_hostname`

