### PR TITLE
[v2] feat: add version api endpoint

### DIFF
--- a/app/Filament/Resources/ApiTokens/Schemas/ApiTokenForm.php
+++ b/app/Filament/Resources/ApiTokens/Schemas/ApiTokenForm.php
@@ -25,6 +25,7 @@ class ApiTokenForm
                             'results:read' => __('api_tokens.read_results'),
                             'speedtests:run' => __('general.run_speedtest'),
                             'ookla:list-servers' => __('general.list_servers'),
+                            'admin:read' => __('api_tokens.admin_read'),
                         ])
                         ->required()
                         ->bulkToggleable()
@@ -32,6 +33,7 @@ class ApiTokenForm
                             'results:read' => __('api_tokens.read_results_description'),
                             'speedtests:run' => __('api_tokens.run_speedtest_description'),
                             'ookla:list-servers' => __('api_tokens.list_servers_description'),
+                            'admin:read' => __('api_tokens.admin_read_description'),
                         ]),
                     DateTimePicker::make('expires_at')
                         ->label(__('api_tokens.expires_at'))

--- a/app/Http/Controllers/Api/V1/VersionController.php
+++ b/app/Http/Controllers/Api/V1/VersionController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Services\GitHub\Repository;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+class VersionController extends ApiController
+{
+    /**
+     * GET /api/v1/version
+     * Returns the currently installed application version and update information.
+     * Restricted to admin users only.
+     */
+    public function __invoke(Request $request)
+    {
+        if ($request->user()->tokenCant('admin:read')) {
+            return $this->sendResponse(
+                data: null,
+                message: 'You do not have permission to view version information.',
+                code: Response::HTTP_FORBIDDEN
+            );
+        }
+
+        $latestVersion = Repository::getLatestVersion();
+
+        return $this->sendResponse(
+            data: [
+                'app' => [
+                    'version' => config('speedtest.build_version'),
+                    'build_date' => config('speedtest.build_date')->toIso8601String(),
+                ],
+                'updates' => [
+                    'latest_version' => $latestVersion ?: null,
+                    'update_available' => Repository::updateAvailable(),
+                ],
+            ]
+        );
+    }
+}

--- a/app/OpenApi/Annotations/V1/VersionAnnotations.php
+++ b/app/OpenApi/Annotations/V1/VersionAnnotations.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\OpenApi\Annotations\V1;
+
+use Illuminate\Http\Response;
+use OpenApi\Attributes as OA;
+
+#[OA\PathItem(
+    path: '/api/v1/version',
+    description: 'Endpoint for retrieving application version information.'
+)]
+class VersionAnnotations
+{
+    #[OA\Get(
+        path: '/api/v1/version',
+        summary: 'Get application version and update information',
+        description: 'Returns the currently installed application version and checks for available updates. Requires admin:read token ability.',
+        operationId: 'getVersion',
+        tags: ['Version'],
+        security: [['bearerAuth' => []]],
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/AcceptHeader'),
+        ],
+        responses: [
+            new OA\Response(
+                response: Response::HTTP_OK,
+                description: 'Version information retrieved successfully',
+                content: new OA\JsonContent(ref: '#/components/schemas/Version')
+            ),
+            new OA\Response(
+                response: Response::HTTP_UNAUTHORIZED,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(ref: '#/components/schemas/UnauthenticatedError')
+            ),
+            new OA\Response(
+                response: Response::HTTP_FORBIDDEN,
+                description: 'Forbidden - Missing admin:read token ability',
+                content: new OA\JsonContent(ref: '#/components/schemas/ForbiddenError')
+            ),
+            new OA\Response(
+                response: Response::HTTP_NOT_ACCEPTABLE,
+                description: 'Not Acceptable - Missing or invalid Accept header',
+                content: new OA\JsonContent(ref: '#/components/schemas/NotAcceptableError')
+            ),
+        ]
+    )]
+    public function getVersion(): void {}
+}

--- a/app/OpenApi/OpenApiDefinition.php
+++ b/app/OpenApi/OpenApiDefinition.php
@@ -42,6 +42,10 @@ use OpenApi\Attributes as OA;
             name: 'Stats',
             description: 'Endpoints for retrieving aggregated statistics and performance metrics. Requires `speedtests:read` token scope.'
         ),
+        new OA\Tag(
+            name: 'Version',
+            description: 'Endpoint for retrieving application version and update information. Requires `admin:read` token scope.'
+        ),
     ]
 )]
 class OpenApiDefinition {}

--- a/app/OpenApi/Schemas/VersionSchema.php
+++ b/app/OpenApi/Schemas/VersionSchema.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\OpenApi\Schemas;
+
+use OpenApi\Attributes as OA;
+
+#[OA\Schema(
+    schema: 'Version',
+    title: 'Version',
+    description: 'Application version and update information',
+    type: 'object',
+    properties: [
+        new OA\Property(
+            property: 'data',
+            type: 'object',
+            properties: [
+                new OA\Property(
+                    property: 'app',
+                    type: 'object',
+                    properties: [
+                        new OA\Property(
+                            property: 'version',
+                            type: 'string',
+                            example: 'v1.13.7'
+                        ),
+                        new OA\Property(
+                            property: 'build_date',
+                            type: 'string',
+                            format: 'date-time',
+                            example: '2026-02-04T00:00:00+00:00'
+                        ),
+                    ]
+                ),
+                new OA\Property(
+                    property: 'updates',
+                    type: 'object',
+                    properties: [
+                        new OA\Property(
+                            property: 'latest_version',
+                            type: 'string',
+                            nullable: true,
+                            example: 'v1.13.8'
+                        ),
+                        new OA\Property(
+                            property: 'update_available',
+                            type: 'boolean',
+                            example: true
+                        ),
+                    ]
+                ),
+            ]
+        ),
+        new OA\Property(
+            property: 'message',
+            type: 'string',
+            example: 'ok'
+        ),
+    ]
+)]
+class VersionSchema {}

--- a/lang/en/api_tokens.php
+++ b/lang/en/api_tokens.php
@@ -27,4 +27,6 @@ return [
     'read_results_description' => 'The token will have permission to read results and statistics.',
     'run_speedtest_description' => 'The token will have permission to run speedtest.',
     'list_servers_description' => 'The token will have permission to list servers.',
+    'admin_read' => 'Admin read',
+    'admin_read_description' => 'The token will have permission to read administrative information such as application version.',
 ];

--- a/openapi.json
+++ b/openapi.json
@@ -269,6 +269,69 @@
                 }
             }
         },
+        "/api/v1/version": {
+            "description": "Endpoint for retrieving application version information.",
+            "get": {
+                "tags": [
+                    "Version"
+                ],
+                "summary": "Get application version and update information",
+                "description": "Returns the currently installed application version and checks for available updates. Requires admin:read token ability.",
+                "operationId": "getVersion",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/AcceptHeader"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Version information retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Version"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthenticatedError"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Forbidden - Missing admin:read token ability",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ForbiddenError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable - Missing or invalid Accept header",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotAcceptableError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
         "/api/v1/ookla/list-servers": {
             "get": {
                 "tags": [
@@ -1146,6 +1209,50 @@
                     }
                 },
                 "type": "object"
+            },
+            "Version": {
+                "title": "Version",
+                "description": "Application version and update information",
+                "properties": {
+                    "data": {
+                        "properties": {
+                            "app": {
+                                "properties": {
+                                    "version": {
+                                        "type": "string",
+                                        "example": "v1.13.7"
+                                    },
+                                    "build_date": {
+                                        "type": "string",
+                                        "format": "date-time",
+                                        "example": "2026-02-04T00:00:00+00:00"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            "updates": {
+                                "properties": {
+                                    "latest_version": {
+                                        "type": "string",
+                                        "example": "v1.13.8",
+                                        "nullable": true
+                                    },
+                                    "update_available": {
+                                        "type": "boolean",
+                                        "example": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        },
+                        "type": "object"
+                    },
+                    "message": {
+                        "type": "string",
+                        "example": "ok"
+                    }
+                },
+                "type": "object"
             }
         },
         "parameters": {
@@ -1180,6 +1287,10 @@
         {
             "name": "Stats",
             "description": "Endpoints for retrieving aggregated statistics and performance metrics. Requires `speedtests:read` token scope."
+        },
+        {
+            "name": "Version",
+            "description": "Endpoint for retrieving application version and update information. Requires `admin:read` token scope."
         },
         {
             "name": "Servers",

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\Api\V1\OoklaController;
 use App\Http\Controllers\Api\V1\ResultsController;
 use App\Http\Controllers\Api\V1\SpeedtestController;
 use App\Http\Controllers\Api\V1\StatsController;
+use App\Http\Controllers\Api\V1\VersionController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->name('api.v1.')->group(function () {
@@ -24,4 +25,7 @@ Route::prefix('v1')->name('api.v1.')->group(function () {
 
     Route::get('/stats', StatsController::class)
         ->name('stats.aggregated');
+
+    Route::get('/version', VersionController::class)
+        ->name('version');
 });

--- a/tests/Feature/VersionEndpointTest.php
+++ b/tests/Feature/VersionEndpointTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+beforeEach(function () {
+    Cache::flush();
+});
+
+describe('version endpoint', function () {
+    test('returns version information for users with admin:read ability', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token', ['admin:read']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/version');
+
+        $response->assertSuccessful()
+            ->assertJsonStructure([
+                'data' => [
+                    'app' => ['name', 'version', 'build_date'],
+                    'updates' => ['latest_version', 'update_available'],
+                ],
+            ])
+            ->assertJsonPath('data.app.version', config('speedtest.build_version'))
+            ->assertJsonPath('data.app.name', config('app.name'));
+    });
+
+    test('denies access for users without admin:read ability', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token', ['results:read']);
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/version');
+
+        $response->assertForbidden()
+            ->assertJsonPath('message', 'You do not have permission to view version information.');
+    });
+
+    test('requires authentication', function () {
+        $response = $this->getJson('/api/v1/version');
+
+        $response->assertUnauthorized();
+    });
+
+    test('includes update information when available', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token', ['admin:read']);
+
+        // Mock the GitHub service to return a known value
+        Cache::put('github.latest_version', 'v1.13.8', now()->addHour());
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/version');
+
+        $response->assertSuccessful()
+            ->assertJsonPath('data.updates.latest_version', 'v1.13.8')
+            ->assertJsonPath('data.updates.update_available', true);
+    });
+
+    test('handles unavailable update information gracefully', function () {
+        $user = User::factory()->create();
+        $token = $user->createToken('test-token', ['admin:read']);
+
+        // Mock GitHub service to return false (unavailable)
+        Cache::put('github.latest_version', false, now()->addHour());
+
+        $response = $this->actingAs($user, 'sanctum')
+            ->getJson('/api/v1/version');
+
+        $response->assertSuccessful()
+            ->assertJsonPath('data.updates.latest_version', null)
+            ->assertJsonPath('data.updates.update_available', false);
+    });
+});


### PR DESCRIPTION
## 📃 Description

This PR adds an API endpoint to check the app version and if there is an update available.

```
{
    "data": {
        "app": {
            "version": "v1.13.7",
            "build_date": "2026-02-04T00:00:00+00:00"
        },
        "updates": {
            "latest_version": "v1.13.9",
            "update_available": true
        }
    },
    "message": "ok"
}
```

Closes #2701 

## 📖 Documentation

OpenAPI spec is updated.

## 🪵 Changelog

### ➕ Added

- `admin:read` token for this API endpoint.
- `VersionController` exposes the current and latest version and performs an update availability check.
- `/version `route in `/api/v1`