### PR TITLE
Add 'All time' option to chart time range filter

### DIFF
--- a/app/Filament/Widgets/Concerns/HasChartFilters.php
+++ b/app/Filament/Widgets/Concerns/HasChartFilters.php
@@ -10,6 +10,7 @@ trait HasChartFilters
             '24h' => __('general.last_24h'),
             'week' => __('general.last_week'),
             'month' => __('general.last_month'),
+            'all' => __('general.all_time'),
         ];
     }
 }

--- a/lang/de_DE/general.php
+++ b/lang/de_DE/general.php
@@ -62,6 +62,7 @@ return [
     'last_24h' => 'Letzte 24 Stunden',
     'last_week' => 'Letzte Woche',
     'last_month' => 'Letzten Monat',
+    'all_time' => 'Gesamter Zeitraum',
 
     // Metrics
     'metrics' => 'Metriken',

--- a/lang/en/general.php
+++ b/lang/en/general.php
@@ -64,6 +64,7 @@ return [
     'last_24h' => 'Last 24 hours',
     'last_week' => 'Last week',
     'last_month' => 'Last month',
+    'all_time' => 'All time',
 
     // Metrics
     'metrics' => 'Metrics',

--- a/lang/es_ES/general.php
+++ b/lang/es_ES/general.php
@@ -64,6 +64,7 @@ return [
     'last_24h' => 'Últimas 24 horas',
     'last_week' => 'Última semana',
     'last_month' => 'Último mes',
+    'all_time' => 'Todo el historial',
 
     // Metrics
     'metrics' => 'Métricas',

--- a/lang/fr_FR/general.php
+++ b/lang/fr_FR/general.php
@@ -62,6 +62,7 @@ return [
     'last_24h' => 'Dernières 24 heures',
     'last_week' => 'La semaine dernière',
     'last_month' => 'Le mois dernier',
+    'all_time' => 'Tout l\'historique',
 
     // Metrics
     'metrics' => 'Métriques',

--- a/lang/nl_NL/general.php
+++ b/lang/nl_NL/general.php
@@ -64,6 +64,7 @@ return [
     'last_24h' => 'Afgelopen 24 uur',
     'last_week' => 'Vorige week',
     'last_month' => 'Vorige maand',
+    'all_time' => 'Alle resultaten',
 
     // Metrics
     'metrics' => 'Statistieken',

--- a/lang/pt_BR/general.php
+++ b/lang/pt_BR/general.php
@@ -64,6 +64,7 @@ return [
     'last_24h' => 'Últimas 24 horas',
     'last_week' => 'Semana passada',
     'last_month' => 'Mês anterior',
+    'all_time' => 'Todo o histórico',
 
     // Metrics
     'metrics' => 'Métricas',


### PR DESCRIPTION
## Summary

Currently the dashboard metrics charts only support three time ranges: Last 24 hours, Last week, and Last month. This adds a fourth option — **All time** — so users can view their complete speedtest history on the charts.

## Changes

- Added `'all'` filter option to the `HasChartFilters` trait
- Added `all_time` translation key to all 6 supported locales (en, de_DE, es_ES, fr_FR, nl_NL, pt_BR)

No changes to the chart widget query logic were needed — the existing `->when()` conditionals in each widget only apply date constraints for the three known filter keys, so any other value (like `'all'`) naturally returns all results without a date filter.

The `DEFAULT_CHART_RANGE` env var also works with the new `all` value out of the box.

<img width="2560" height="784" alt="Screenshot_20260228_224634" src="https://github.com/user-attachments/assets/faee977c-85c1-4356-82ab-13d941ea1b19" />


## Test plan

- [x] Select "All time" from the chart filter dropdown on the dashboard
- [x] Verify all chart widgets (download, upload, ping, jitter, download latency, upload latency) display the full history
- [x] Set `DEFAULT_CHART_RANGE=all` in `.env` and verify charts default to all time on page load
- [x] Check that existing filter options (24h, week, month) still work as expected