### PR TITLE
fix: respect TZ env var as fallback for timezone config

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', 'UTC'),
+    'timezone' => env('APP_TIMEZONE', env('TZ', 'UTC')),
 
     /*
     |--------------------------------------------------------------------------
@@ -151,7 +151,7 @@ return [
 
     'datetime_format' => env('DATETIME_FORMAT', 'M. j, Y g:ia'),
 
-    'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),
+    'display_timezone' => env('DISPLAY_TIMEZONE', env('TZ', 'UTC')),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', env('TZ', 'UTC')),
+    'timezone' => env('APP_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------
@@ -151,7 +151,7 @@ return [
 
     'datetime_format' => env('DATETIME_FORMAT', 'M. j, Y g:ia'),
 
-    'display_timezone' => env('DISPLAY_TIMEZONE', env('TZ', 'UTC')),
+    'display_timezone' => env('DISPLAY_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `TZ` as a fallback in the env chain for both `timezone` and `display_timezone` in `config/app.php`, so the standard Docker `TZ` variable is respected when `APP_TIMEZONE` / `DISPLAY_TIMEZONE` are not set.

## The problem

Docker users typically set timezone via `TZ=Europe/London` in their compose file. Currently, both config values fall back directly to `'UTC'`, ignoring `TZ` entirely. This causes times to display in UTC even when the container's system clock is correct.

This has been reported in #939, #1503, #805, #1739, and #1214 — all closed with "set `APP_TIMEZONE` and `DISPLAY_TIMEZONE`" as the workaround.

## The fix

```php
// Before
'timezone' => env('APP_TIMEZONE', 'UTC'),
'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),

// After
'timezone' => env('APP_TIMEZONE', env('TZ', 'UTC')),
'display_timezone' => env('DISPLAY_TIMEZONE', env('TZ', 'UTC')),
```

Resolution order: `APP_TIMEZONE` → `TZ` → `UTC`

Non-breaking — existing deployments with `APP_TIMEZONE` or `DISPLAY_TIMEZONE` are unaffected.