### PR TITLE
chore: remove hardcoded HTTP timeouts, use Laravel's 30s default

### DIFF
--- a/app/Actions/GetExternalIpAddress.php
+++ b/app/Actions/GetExternalIpAddress.php
@@ -18,7 +18,6 @@ class GetExternalIpAddress
 
         try {
             $response = Http::retry(3, 100)
-                ->timeout(5)
                 ->get(url: $url);
         } catch (Throwable $e) {
             $message = sprintf('Failed to fetch external IP address from "%s". See the logs for more details.', $url);

--- a/app/Actions/GetOoklaSpeedtestServers.php
+++ b/app/Actions/GetOoklaSpeedtestServers.php
@@ -45,7 +45,6 @@ class GetOoklaSpeedtestServers
 
         try {
             $response = Http::retry(3, 250)
-                ->timeout(5)
                 ->get(url: 'https://www.speedtest.net/api/js/servers', query: $query);
 
             return $response->json();

--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -86,7 +86,6 @@ class CheckForInternetConnectionJob implements ShouldQueue
 
         try {
             $response = Http::retry(3, 100)
-                ->timeout(5)
                 ->get(url: $url);
 
             if ($response->ok()) {

--- a/app/Notifications/AppriseChannel.php
+++ b/app/Notifications/AppriseChannel.php
@@ -38,10 +38,9 @@ class AppriseChannel
         ]);
 
         try {
-            $request = Http::timeout(60)
-                ->withHeaders([
-                    'Content-Type' => 'application/json',
-                ]);
+            $request = Http::withHeaders([
+                'Content-Type' => 'application/json',
+            ]);
 
             // If SSL verification is disabled in settings, skip it
             if (! $settings->apprise_verify_ssl) {

--- a/app/Services/GitHub/Repository.php
+++ b/app/Services/GitHub/Repository.php
@@ -19,7 +19,6 @@ class Repository
         return Cache::remember('github.latest_version', now()->addHour(), function () {
             try {
                 $response = Http::retry(3, 100)
-                    ->timeout(10)
                     ->withHeaders([
                         'Accept' => 'application/vnd.github.v3+json',
                         'User-Agent' => 'speedtest-tracker',


### PR DESCRIPTION
## 📃 Description

Removes hardcoded HTTP timeouts from `GetOoklaSpeedtestServers` and `AppriseChannel`, letting both fall back to Laravel's built-in 30-second default. The previous 5-second timeout on the Ookla server list endpoint was to short in slow networks..

Closes #2787

## 🪵 Changelog

### 🗑️ Removed

- Removed hardcoded `->timeout(5)` from `GetOoklaSpeedtestServers` — now uses Laravel's 30-second default
- Removed hardcoded `->timeout(60)` from `AppriseChannel` — now uses Laravel's 30-second default
- Removed hardcoded `->timeout(5)` from `GetExternalIpAddress` — now uses Laravel's 30-second default
- Removed hardcoded `->timeout(5)` from `CheckForInternetConnectionJob` — now uses Laravel's 30-second default
- Removed hardcoded `->timeout(10)` from `Repository` — now uses Laravel's 30-second default
