### PR TITLE
refactor: improve prometheus export to follow standard conventions

### DIFF
--- a/app/Listeners/ProcessSpeedtestDataIntegrations.php
+++ b/app/Listeners/ProcessSpeedtestDataIntegrations.php
@@ -5,8 +5,8 @@ namespace App\Listeners;
 use App\Events\SpeedtestCompleted;
 use App\Events\SpeedtestFailed;
 use App\Jobs\Influxdb\v2\WriteResult;
+use App\Services\PrometheusMetricsService;
 use App\Settings\DataIntegrationSettings;
-use Illuminate\Support\Facades\Cache;
 
 class ProcessSpeedtestDataIntegrations
 {
@@ -15,6 +15,7 @@ class ProcessSpeedtestDataIntegrations
      */
     public function __construct(
         public DataIntegrationSettings $settings,
+        public PrometheusMetricsService $prometheusService
     ) {}
 
     /**
@@ -27,7 +28,9 @@ class ProcessSpeedtestDataIntegrations
         }
 
         if ($this->settings->prometheus_enabled) {
-            Cache::forever('prometheus:latest_result', $event->result->id);
+            // Update Prometheus metrics cache when speedtest completes/fails
+            // This prevents rebuilding metrics on every scrape
+            $this->prometheusService->updateMetrics($event->result);
         }
     }
 }

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -49,6 +49,14 @@ class Result extends Model
     }
 
     /**
+     * Scope a query to only include completed results.
+     */
+    public function scopeCompleted(Builder $query): Builder
+    {
+        return $query->where('status', ResultStatus::Completed);
+    }
+
+    /**
      * Get the user who dispatched this speedtest.
      */
     public function dispatchedBy(): BelongsTo

--- a/app/Services/PrometheusMetricsService.php
+++ b/app/Services/PrometheusMetricsService.php
@@ -2,9 +2,7 @@
 
 namespace App\Services;
 
-use App\Enums\ResultStatus;
 use App\Models\Result;
-use App\Settings\DataIntegrationSettings;
 use Illuminate\Support\Facades\Cache;
 use Prometheus\CollectorRegistry;
 use Prometheus\RenderTextFormat;
@@ -12,31 +10,25 @@ use Prometheus\Storage\InMemory;
 
 class PrometheusMetricsService
 {
-    public function __construct(
-        protected DataIntegrationSettings $settings
-    ) {}
-
     public function generateMetrics(): string
     {
+        // Return cached metrics if available
+        // This avoids rebuilding the registry and querying the DB on every scrape
+        return Cache::get('prometheus:metrics', fn () => $this->emptyMetrics());
+    }
+
+    public function updateMetrics(Result $result): void
+    {
+        // Build metrics only when data changes (speedtest completes/fails)
         $registry = new CollectorRegistry(new InMemory);
 
-        $resultId = Cache::get('prometheus:latest_result');
-
-        if (! $resultId) {
-            return $this->emptyMetrics();
-        }
-
-        $lastResult = Result::find($resultId);
-
-        if (! $lastResult) {
-            return $this->emptyMetrics();
-        }
-
-        $this->registerMetrics($registry, $lastResult);
+        $this->registerMetrics($registry, $result);
 
         $renderer = new RenderTextFormat;
+        $metrics = $renderer->render($registry->getMetricFamilySamples());
 
-        return $renderer->render($registry->getMetricFamilySamples());
+        // Cache the rendered metrics so scrapes don't rebuild every time
+        Cache::forever('prometheus:metrics', $metrics);
     }
 
     protected function registerMetrics(CollectorRegistry $registry, Result $result): void
@@ -44,104 +36,80 @@ class PrometheusMetricsService
         $labels = $this->buildLabels($result);
         $labelNames = array_keys($labels);
         $labelValues = array_values($labels);
+        $timestamp = $result->updated_at?->timestamp;
 
-        // Info metric - always exported so users can see test status (including failures)
-        $infoGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'result_id',
-            'Speedtest result id',
-            $labelNames
-        );
-        $infoGauge->set($result->id, $labelValues);
+        $this->registerStaticMetrics($registry);
 
-        // Only export numeric metrics for completed tests
-        // Failed/incomplete tests won't have valid measurements
-        if ($result->status !== ResultStatus::Completed) {
-            return;
+        // Info metric - always set to 1, metadata in labels
+        // Exported for both completed and failed tests so Prometheus can track all test attempts
+        $infoGauge = $registry->getOrRegisterGauge('speedtest_tracker', 'info', 'Speedtest metadata and status', $labelNames);
+        $infoGauge->set(1, $labelValues, $timestamp);
+
+        // Register all speed/latency metrics
+        // Failed tests will have null values, which registerGaugeIfNotNull automatically skips
+
+        // Speed metrics (rates)
+        $this->registerGaugeIfNotNull($registry, 'download_bytes_per_second', 'Download speed in bytes per second', $labelNames, $labelValues, $result->download, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_bytes_per_second', 'Upload speed in bytes per second', $labelNames, $labelValues, $result->upload, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'download_bits_per_second', 'Download speed in bits per second', $labelNames, $labelValues, $result->download_bits, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_bits_per_second', 'Upload speed in bits per second', $labelNames, $labelValues, $result->upload_bits, $timestamp);
+
+        // Ping metrics
+        $this->registerGaugeIfNotNull($registry, 'ping_ms', 'Ping latency in milliseconds', $labelNames, $labelValues, $result->ping, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'ping_low_ms', 'Ping low latency in milliseconds', $labelNames, $labelValues, $result->ping_low, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'ping_high_ms', 'Ping high latency in milliseconds', $labelNames, $labelValues, $result->ping_high, $timestamp);
+
+        // Jitter metrics
+        $this->registerGaugeIfNotNull($registry, 'ping_jitter_ms', 'Ping jitter in milliseconds', $labelNames, $labelValues, $result->ping_jitter, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'download_jitter_ms', 'Download jitter in milliseconds', $labelNames, $labelValues, $result->download_jitter, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_jitter_ms', 'Upload jitter in milliseconds', $labelNames, $labelValues, $result->upload_jitter, $timestamp);
+
+        // Packet loss
+        $this->registerGaugeIfNotNull($registry, 'packet_loss_percent', 'Packet loss percentage', $labelNames, $labelValues, $result->packet_loss, $timestamp);
+
+        // Download latency metrics (IQM = Interquartile Mean - more reliable than average)
+        $this->registerGaugeIfNotNull($registry, 'download_latency_iqm_ms', 'Download latency interquartile mean in milliseconds', $labelNames, $labelValues, $result->downloadlatencyiqm, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'download_latency_low_ms', 'Download latency low in milliseconds', $labelNames, $labelValues, $result->downloadlatency_low, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'download_latency_high_ms', 'Download latency high in milliseconds', $labelNames, $labelValues, $result->downloadlatency_high, $timestamp);
+
+        // Upload latency metrics
+        $this->registerGaugeIfNotNull($registry, 'upload_latency_iqm_ms', 'Upload latency interquartile mean in milliseconds', $labelNames, $labelValues, $result->uploadlatencyiqm, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_latency_low_ms', 'Upload latency low in milliseconds', $labelNames, $labelValues, $result->uploadlatency_low, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_latency_high_ms', 'Upload latency high in milliseconds', $labelNames, $labelValues, $result->uploadlatency_high, $timestamp);
+
+        // Bytes transferred during test (cumulative totals)
+        $this->registerGaugeIfNotNull($registry, 'test_downloaded_bytes_total', 'Total bytes downloaded during test', $labelNames, $labelValues, $result->downloaded_bytes, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'test_uploaded_bytes_total', 'Total bytes uploaded during test', $labelNames, $labelValues, $result->uploaded_bytes, $timestamp);
+
+        // Test duration
+        $this->registerGaugeIfNotNull($registry, 'download_elapsed_ms', 'Download test duration in milliseconds', $labelNames, $labelValues, $result->download_elapsed, $timestamp);
+        $this->registerGaugeIfNotNull($registry, 'upload_elapsed_ms', 'Upload test duration in milliseconds', $labelNames, $labelValues, $result->upload_elapsed, $timestamp);
+    }
+
+    protected function registerGaugeIfNotNull(
+        CollectorRegistry $registry,
+        string $name,
+        string $help,
+        array $labelNames,
+        array $labelValues,
+        mixed $value,
+        ?int $timestamp = null
+    ): void {
+        if ($value !== null) {
+            $gauge = $registry->getOrRegisterGauge(
+                'speedtest_tracker',
+                $name,
+                $help,
+                $labelNames
+            );
+            $gauge->set($value, $labelValues, $timestamp);
         }
-
-        // Download speed in bytes
-        $downloadBytesGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'download_bytes',
-            'Download speed in bytes per second',
-            $labelNames
-        );
-        $downloadBytesGauge->set($result->download, $labelValues);
-
-        // Upload speed in bytes
-        $uploadBytesGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'upload_bytes',
-            'Upload speed in bytes per second',
-            $labelNames
-        );
-        $uploadBytesGauge->set($result->upload, $labelValues);
-
-        // Download speed in bits per second
-        $downloadBitsGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'download_bits',
-            'Download speed in bits per second',
-            $labelNames
-        );
-        $downloadBitsGauge->set(toBits($result->download), $labelValues);
-
-        // Upload speed in bits per second
-        $uploadBitsGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'upload_bits',
-            'Upload speed in bits per second',
-            $labelNames
-        );
-        $uploadBitsGauge->set(toBits($result->upload), $labelValues);
-
-        // Ping latency in milliseconds
-        $pingGauge = $registry->getOrRegisterGauge(
-            'speedtest_tracker',
-            'ping_ms',
-            'Ping latency in milliseconds',
-            $labelNames
-        );
-        $pingGauge->set($result->ping, $labelValues);
-
-        // Jitter metrics - optional, may not be present in all test results
-        $this->registerGaugeIfNotNull($registry, 'ping_jitter_ms', 'Ping jitter in milliseconds', $labelNames, $labelValues, $result->ping_jitter);
-        $this->registerGaugeIfNotNull($registry, 'download_jitter_ms', 'Download jitter in milliseconds', $labelNames, $labelValues, $result->download_jitter);
-        $this->registerGaugeIfNotNull($registry, 'upload_jitter_ms', 'Upload jitter in milliseconds', $labelNames, $labelValues, $result->upload_jitter);
-
-        // Packet loss - optional
-        $this->registerGaugeIfNotNull($registry, 'packet_loss_percent', 'Packet loss percentage', $labelNames, $labelValues, $result->packet_loss);
-
-        // Ping latency metrics - optional
-        $this->registerGaugeIfNotNull($registry, 'ping_low_ms', 'Ping low latency in milliseconds', $labelNames, $labelValues, $result->ping_low);
-        $this->registerGaugeIfNotNull($registry, 'ping_high_ms', 'Ping high latency in milliseconds', $labelNames, $labelValues, $result->ping_high);
-
-        // Download latency metrics - optional (IQM = Interquartile Mean - more reliable than average)
-        $this->registerGaugeIfNotNull($registry, 'download_latency_iqm_ms', 'Download latency interquartile mean in milliseconds', $labelNames, $labelValues, $result->downloadlatencyiqm);
-        $this->registerGaugeIfNotNull($registry, 'download_latency_low_ms', 'Download latency low in milliseconds', $labelNames, $labelValues, $result->downloadlatency_low);
-        $this->registerGaugeIfNotNull($registry, 'download_latency_high_ms', 'Download latency high in milliseconds', $labelNames, $labelValues, $result->downloadlatency_high);
-
-        // Upload latency metrics - optional
-        $this->registerGaugeIfNotNull($registry, 'upload_latency_iqm_ms', 'Upload latency interquartile mean in milliseconds', $labelNames, $labelValues, $result->uploadlatencyiqm);
-        $this->registerGaugeIfNotNull($registry, 'upload_latency_low_ms', 'Upload latency low in milliseconds', $labelNames, $labelValues, $result->uploadlatency_low);
-        $this->registerGaugeIfNotNull($registry, 'upload_latency_high_ms', 'Upload latency high in milliseconds', $labelNames, $labelValues, $result->uploadlatency_high);
-
-        // Bytes transferred during test - optional
-        $this->registerGaugeIfNotNull($registry, 'downloaded_bytes', 'Total bytes downloaded during test', $labelNames, $labelValues, $result->downloaded_bytes);
-        $this->registerGaugeIfNotNull($registry, 'uploaded_bytes', 'Total bytes uploaded during test', $labelNames, $labelValues, $result->uploaded_bytes);
-
-        // Test duration - optional
-        $this->registerGaugeIfNotNull($registry, 'download_elapsed_ms', 'Download test duration in milliseconds', $labelNames, $labelValues, $result->download_elapsed);
-        $this->registerGaugeIfNotNull($registry, 'upload_elapsed_ms', 'Upload test duration in milliseconds', $labelNames, $labelValues, $result->upload_elapsed);
     }
 
     protected function buildLabels(Result $result): array
     {
         return [
-            'server_id' => (string) ($result->server_id ?? ''),
             'server_name' => $result->server_name ?? '',
-            'server_country' => $result->server_country ?? '',
             'server_location' => $result->server_location ?? '',
             'isp' => $result->isp ?? '',
             'scheduled' => $result->scheduled ? 'true' : 'false',
@@ -151,31 +119,21 @@ class PrometheusMetricsService
         ];
     }
 
-    protected function emptyMetrics(): string
+    protected function registerStaticMetrics(CollectorRegistry $registry): void
     {
-        return "# no data available\n";
+        $up = $registry->getOrRegisterGauge('speedtest_tracker', 'up', 'Exporter is responding');
+        $up->set(1, []);
+
+        $buildInfo = $registry->getOrRegisterGauge('speedtest_tracker', 'build_info', 'Application version information', ['version']);
+        $buildInfo->set(1, [config('speedtest.build_version')]);
     }
 
-    /**
-     * Register a gauge metric only if the value is not null.
-     * Follows Prometheus best practice of not exporting missing metrics.
-     */
-    protected function registerGaugeIfNotNull(
-        CollectorRegistry $registry,
-        string $name,
-        string $help,
-        array $labelNames,
-        array $labelValues,
-        mixed $value
-    ): void {
-        if ($value !== null) {
-            $gauge = $registry->getOrRegisterGauge(
-                'speedtest_tracker',
-                $name,
-                $help,
-                $labelNames
-            );
-            $gauge->set($value, $labelValues);
-        }
+    protected function emptyMetrics(): string
+    {
+        $registry = new CollectorRegistry(new InMemory);
+
+        $this->registerStaticMetrics($registry);
+
+        return (new RenderTextFormat)->render($registry->getMetricFamilySamples());
     }
 }

--- a/tests/Feature/MetricsEndpointTest.php
+++ b/tests/Feature/MetricsEndpointTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Result;
+use App\Services\PrometheusMetricsService;
 use App\Settings\DataIntegrationSettings;
 use Illuminate\Support\Facades\Cache;
 
@@ -23,7 +24,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => [],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus');
 
@@ -50,7 +54,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['192.168.1.100', '10.0.0.1'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.100',
@@ -66,7 +73,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => [],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '10.0.0.1',
@@ -81,7 +91,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['192.168.1.0/24'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.150',
@@ -109,7 +122,10 @@ describe('metrics endpoint', function () {
             'prometheus_allowed_ips' => ['10.0.0.1', '192.168.1.0/24'],
         ])->save();
 
-        Result::factory()->create();
+        $result = Result::factory()->create();
+
+        // Simulate the listener updating metrics
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus', [
             'REMOTE_ADDR' => '192.168.1.50',
@@ -124,61 +140,63 @@ describe('metrics endpoint', function () {
         $response->assertSuccessful();
     });
 
-    test('handles results with missing packet loss data', function () {
+    test('completed result emits expected metric names in response body', function () {
         app(DataIntegrationSettings::class)->fill([
             'prometheus_enabled' => true,
             'prometheus_allowed_ips' => [],
         ])->save();
 
-        // Create a result without packet loss data
-        $dataWithoutPacketLoss = json_decode('{"isp": "Speedtest Communications", "ping": {"low": 17.841, "high": 24.077, "jitter": 1.878, "latency": 19.133}, "type": "result", "result": {"id": "d6fe2fb3-f4f8-4cc5-b898-7b42109e67c2", "url": "https://docs.speedtest-tracker.dev", "persisted": true}, "server": {"id": 0, "ip": "127.0.0.1", "host": "docs.speedtest-tracker.dev", "name": "Speedtest", "port": 8080, "country": "United States", "location": "New York City, NY"}, "upload": {"bytes": 124297377, "elapsed": 9628, "latency": {"iqm": 341.111, "low": 16.663, "high": 529.86, "jitter": 37.587}, "bandwidth": 113750000}, "download": {"bytes": 230789788, "elapsed": 14301, "latency": {"iqm": 104.125, "low": 23.72, "high": 269.563, "jitter": 13.447}, "bandwidth": 115625000}, "interface": {"name": "eth0", "isVpn": false, "macAddr": "00:00:00:00:00:00", "externalIp": "127.0.0.1", "internalIp": "127.0.0.1"}, "timestamp": "2024-03-01T01:00:00Z"}', true);
-
-        Result::factory()->create([
-            'ping' => $dataWithoutPacketLoss['ping']['latency'],
-            'download' => $dataWithoutPacketLoss['download']['bandwidth'],
-            'upload' => $dataWithoutPacketLoss['upload']['bandwidth'],
-            'data' => $dataWithoutPacketLoss,
+        $result = Result::factory()->create([
+            'status' => \App\Enums\ResultStatus::Completed,
+            'download' => 115625000,
+            'upload' => 113750000,
         ]);
+
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus');
 
         $response->assertSuccessful();
-        $response->assertHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
-        // Verify packet_loss metric is not in the output when data is missing
-        expect($response->getContent())->not->toContain('speedtest_tracker_packet_loss_percent');
+        $response->assertSee('speedtest_tracker_up');
+        $response->assertSee('speedtest_tracker_info');
+        $response->assertSee('speedtest_tracker_download_bytes_per_second');
+        $response->assertSee('speedtest_tracker_upload_bytes_per_second');
+        $response->assertSee('speedtest_tracker_download_bits_per_second');
+        $response->assertSee('speedtest_tracker_upload_bits_per_second');
     });
 
-    test('handles failed speedtests by only exporting info metric', function () {
+    test('failed result does not emit speed gauge metrics', function () {
         app(DataIntegrationSettings::class)->fill([
             'prometheus_enabled' => true,
             'prometheus_allowed_ips' => [],
         ])->save();
-
-        // Create a failed result
-        $failedData = json_decode('{"type": "log", "level": "error", "message": "Connection timeout", "timestamp": "2024-03-01T01:00:00Z"}', true);
 
         $result = Result::factory()->create([
             'status' => \App\Enums\ResultStatus::Failed,
-            'data' => $failedData,
+            'download' => null,
+            'upload' => null,
+            'ping' => null,
+            'data' => ['type' => 'log', 'level' => 'error', 'message' => 'Test error.', 'timestamp' => '2024-03-01T01:00:00Z'],
         ]);
 
-        // Cache the result ID so the Prometheus service can find it
-        Cache::forever('prometheus:latest_result', $result->id);
+        app(PrometheusMetricsService::class)->updateMetrics($result);
 
         $response = $this->get('/prometheus');
 
         $response->assertSuccessful();
-        $response->assertHeader('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+        $response->assertSee('speedtest_tracker_up');
+        $response->assertSee('speedtest_tracker_info');
+        $response->assertDontSee('speedtest_tracker_download_bytes_per_second');
+        $response->assertDontSee('speedtest_tracker_upload_bytes_per_second');
+        $response->assertDontSee('speedtest_tracker_download_bits_per_second');
+        $response->assertDontSee('speedtest_tracker_upload_bits_per_second');
+    });
 
-        $content = $response->getContent();
+    test('generateMetrics returns up and build_info metrics when no cache exists', function () {
+        $metrics = app(PrometheusMetricsService::class)->generateMetrics();
 
-        // Should have the info metric (result_id)
-        expect($content)->toContain('speedtest_tracker_result_id');
-
-        // Should NOT have numeric metrics for failed tests
-        expect($content)->not->toContain('speedtest_tracker_download_bytes');
-        expect($content)->not->toContain('speedtest_tracker_upload_bytes');
-        expect($content)->not->toContain('speedtest_tracker_ping_ms');
-        expect($content)->not->toContain('speedtest_tracker_packet_loss_percent');
+        expect($metrics)
+            ->toContain('speedtest_tracker_up 1')
+            ->toContain('speedtest_tracker_build_info');
     });
 });

--- a/tests/Unit/ResultTest.php
+++ b/tests/Unit/ResultTest.php
@@ -1,14 +1,16 @@
 <?php
 
+use App\Enums\ResultStatus;
 use App\Models\Result;
-use Illuminate\Support\Facades\Cache;
 
-beforeEach(function () {
-    Cache::flush();
-});
+it('scopes results to only completed status', function () {
+    Result::factory()->create(['status' => ResultStatus::Completed]);
+    Result::factory()->create(['status' => ResultStatus::Completed]);
+    Result::factory()->create(['status' => ResultStatus::Failed]);
+    Result::factory()->create(['status' => ResultStatus::Running]);
 
-test('can use factory to create a Result model', function () {
-    Result::factory()->create();
+    $completedResults = Result::completed()->get();
 
-    expect(Result::count())->toBe(1);
+    expect($completedResults)->toHaveCount(2);
+    expect($completedResults->every(fn ($result) => $result->status === ResultStatus::Completed))->toBeTrue();
 });


### PR DESCRIPTION
## 📃 Description

This PR significantly improves the Prometheus metrics implementation to follow best practices and standard conventions.

## 🪵 Changelog

### ➕ Added

- Added standard metrics:
    - `speedtest_tracker_up` - Exporter health indicator (always 1)
    - `speedtest_tracker_build_info` - Application version metadata
- `registerGaugeIfNotNull` helper to skip null metrics for failed tests

### ✏️ Changed

- Cache rendered metrics, only rebuild when a scheduled speedtest completes or fails
- Cache default is evaluated lazily so no registry is built on cache hits
- Metrics endpoint now returns valid `up` and `build_info` metrics before any speedtest has run, instead of a plain comment string
- Improved metric naming:
   - `download_bytes` → `download_bytes_per_second` (explicit rate)
   - `upload_bytes` → `upload_bytes_per_second` (explicit rate)
   - `download_bits` → `download_bits_per_second` (explicit rate)
   - `upload_bits` → `upload_bits_per_second` (explicit rate)
   - `downloaded_bytes` → `test_downloaded_bytes_total` (cumulative total)
   - `uploaded_bytes` → `test_uploaded_bytes_total` (cumulative total)

### 🗑️ Removed

- Removed `server_id` label
- Removed `server_country` label
