### PR TITLE
Feat: add 2fa support

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,12 @@
 namespace App\Models;
 
 use App\Enums\UserRole;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthentication;
+use Filament\Auth\MultiFactor\App\Concerns\InteractsWithAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\Email\Concerns\InteractsWithEmailAuthentication;
+use Filament\Auth\MultiFactor\Email\Contracts\HasEmailAuthentication;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -11,9 +17,9 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
-class User extends Authenticatable implements FilamentUser
+class User extends Authenticatable implements FilamentUser, HasAppAuthentication, HasAppAuthenticationRecovery, HasEmailAuthentication
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, InteractsWithAppAuthentication, InteractsWithAppAuthenticationRecovery, InteractsWithEmailAuthentication, Notifiable;
 
     /**
      * The attributes that are mass assignable.

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers\Filament;
 
+use Filament\Auth\MultiFactor\App\AppAuthentication;
+use Filament\Auth\MultiFactor\Email\EmailAuthentication;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
 use Filament\Http\Middleware\DispatchServingFilamentEvent;
@@ -27,6 +29,10 @@ class AdminPanelProvider extends PanelProvider
             ->path('admin')
             ->login()
             ->profile(isSimple: false)
+            ->multiFactorAuthentication([
+                AppAuthentication::make()->recoverable(),
+                EmailAuthentication::make()->codeExpiryMinutes(10),
+            ])
             ->colors([
                 'primary' => Color::Amber,
             ])

--- a/database/migrations/2026_06_24_175534_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2026_06_24_175534_add_two_factor_columns_to_users_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('app_authentication_secret')->nullable();
+            $table->text('app_authentication_recovery_codes')->nullable();
+            $table->boolean('has_email_authentication')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['app_authentication_secret', 'app_authentication_recovery_codes', 'has_email_authentication']);
+        });
+    }
+};

--- a/tests/Feature/TwoFactorAuthenticationTest.php
+++ b/tests/Feature/TwoFactorAuthenticationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Models\User;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthentication;
+use Filament\Auth\MultiFactor\App\Contracts\HasAppAuthenticationRecovery;
+use Filament\Auth\MultiFactor\Email\Contracts\HasEmailAuthentication;
+use Filament\Auth\Pages\EditProfile;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+
+describe('User model', function () {
+    it('implements the required MFA interfaces', function () {
+        $user = User::factory()->create();
+
+        expect($user)->toBeInstanceOf(HasAppAuthentication::class)
+            ->toBeInstanceOf(HasAppAuthenticationRecovery::class)
+            ->toBeInstanceOf(HasEmailAuthentication::class);
+    });
+
+    it('has the app_authentication_secret column defaulting to null', function () {
+        $user = User::factory()->create(['app_authentication_secret' => null]);
+
+        expect($user->getAppAuthenticationSecret())->toBeNull();
+    });
+
+    it('has the app_authentication_recovery_codes column defaulting to null', function () {
+        $user = User::factory()->create(['app_authentication_recovery_codes' => null]);
+
+        expect($user->getAppAuthenticationRecoveryCodes())->toBeNull();
+    });
+
+    it('has email authentication disabled by default', function () {
+        $user = User::factory()->create();
+
+        expect($user->hasEmailAuthentication())->toBeFalse();
+    });
+});
+
+describe('Profile page', function () {
+    it('loads successfully for an authenticated user', function () {
+        $user = User::factory()->create();
+
+        actingAs($user);
+
+        Livewire::test(EditProfile::class)
+            ->assertOk();
+    });
+});


### PR DESCRIPTION
## 📃 Description

Adds optional two-factor authentication (2FA) support to the Filament admin panel. Users can enable either a TOTP authenticator app (Google Authenticator, Authy, etc.) or email-based one-time codes from their profile page. App-based 2FA includes recovery codes in case the authenticator is lost.

Closes #344



## 🪵 Changelog

### ➕ Added

- Two-factor authentication via TOTP authenticator app (Google Authenticator, Authy, Microsoft Authenticator)
- Recovery codes for TOTP app authentication, regeneratable from the profile page
- Two-factor authentication via email one-time codes
- Migration adding `app_authentication_secret`, `app_authentication_recovery_codes`, and `has_email_authentication` columns to the `users` table

### ✏️ Changed

- `User` model now implements `HasAppAuthentication`, `HasAppAuthenticationRecovery`, and `HasEmailAuthentication` interfaces with their corresponding Filament traits
- Admin panel now registers both MFA providers (app + email) as optional — users opt in from their profile page
