### PR TITLE
feat: add general settings page

### DIFF
--- a/app/Actions/CheckForScheduledSpeedtests.php
+++ b/app/Actions/CheckForScheduledSpeedtests.php
@@ -3,6 +3,7 @@
 namespace App\Actions;
 
 use App\Actions\Ookla\RunSpeedtest;
+use App\Settings\GeneralSettings;
 use Cron\CronExpression;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -33,7 +34,7 @@ class CheckForScheduledSpeedtests
 
         return $cron->isDue(
             currentTime: now(),
-            timeZone: config('app.display_timezone')
+            timeZone: app(GeneralSettings::class)->display_timezone
         );
     }
 }

--- a/app/Actions/GetExternalIpAddress.php
+++ b/app/Actions/GetExternalIpAddress.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions;
 
+use App\Settings\GeneralSettings;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -14,7 +15,7 @@ class GetExternalIpAddress
 
     public function handle(?string $url = null): array
     {
-        $url = $url ?? config('speedtest.preflight.external_ip_url');
+        $url = $url ?? app(GeneralSettings::class)->speedtest_external_ip_url;
 
         try {
             $response = Http::retry(3, 100)

--- a/app/Actions/PingHostname.php
+++ b/app/Actions/PingHostname.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions;
 
+use App\Settings\GeneralSettings;
 use Illuminate\Support\Facades\Log;
 use Lorisleiva\Actions\Concerns\AsAction;
 use Spatie\Ping\Ping;
@@ -18,7 +19,7 @@ class PingHostname
      */
     public function handle(?string $hostname = null, int $count = 1): ?PingResult
     {
-        $hostname = $hostname ?? config('speedtest.preflight.internet_check_hostname');
+        $hostname = $hostname ?? app(GeneralSettings::class)->speedtest_internet_check_hostname;
 
         // Remove protocol if present
         $hostname = preg_replace('#^https?://#', '', $hostname);

--- a/app/Filament/Pages/Settings/General.php
+++ b/app/Filament/Pages/Settings/General.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace App\Filament\Pages\Settings;
+
+use App\Settings\GeneralSettings;
+use Filament\Actions\Action;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Illuminate\Support\Facades\Auth;
+
+class General extends SettingsPage
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'tabler-settings';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Settings';
+
+    protected static ?int $navigationSort = 1;
+
+    public function getTitle(): string
+    {
+        return __('settings/general.title');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('settings/general.label');
+    }
+
+    protected static string $settings = GeneralSettings::class;
+
+    public static function canAccess(): bool
+    {
+        return Auth::check() && Auth::user()->is_admin;
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        return Auth::check() && Auth::user()->is_admin;
+    }
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Tabs::make()
+                    ->schema([
+                        Tab::make(__('settings/general.display'))
+                            ->icon(Heroicon::OutlinedComputerDesktop)
+                            ->schema([
+                                Grid::make(['default' => 1, 'md' => 2])
+                                    ->schema([
+                                        Select::make('display_timezone')
+                                            ->label(__('settings/general.display_timezone'))
+                                            ->helperText(__('settings/general.display_timezone_helper_text'))
+                                            ->options(fn (): array => array_combine(
+                                                \DateTimeZone::listIdentifiers(),
+                                                \DateTimeZone::listIdentifiers(),
+                                            ))
+                                            ->searchable()
+                                            ->required(),
+                                        TextInput::make('datetime_format')
+                                            ->label(__('settings/general.datetime_format'))
+                                            ->helperText(__('settings/general.datetime_format_helper_text'))
+                                            ->hintAction(
+                                                Action::make('datetime_format_docs')
+                                                    ->label(__('settings/general.datetime_format_docs'))
+                                                    ->icon(Heroicon::OutlinedQuestionMarkCircle)
+                                                    ->url('https://www.php.net/manual/en/datetime.format.php')
+                                                    ->openUrlInNewTab()
+                                            )
+                                            ->required(),
+                                        TextInput::make('chart_datetime_format')
+                                            ->label(__('settings/general.chart_datetime_format'))
+                                            ->helperText(__('settings/general.chart_datetime_format_helper_text'))
+                                            ->hintAction(
+                                                Action::make('chart_datetime_format_docs')
+                                                    ->label(__('settings/general.datetime_format_docs'))
+                                                    ->icon(Heroicon::OutlinedQuestionMarkCircle)
+                                                    ->url('https://www.php.net/manual/en/datetime.format.php')
+                                                    ->openUrlInNewTab()
+                                            )
+                                            ->required(),
+                                        Toggle::make('chart_begin_at_zero')
+                                            ->label(__('settings/general.chart_begin_at_zero'))
+                                            ->columnSpanFull(),
+                                    ]),
+                            ])
+                            ->columnSpanFull(),
+
+                        Tab::make(__('settings/general.charts'))
+                            ->icon(Heroicon::OutlinedChartBar)
+                            ->schema([
+                                Grid::make(['default' => 1, 'md' => 2])
+                                    ->schema([
+                                        Select::make('default_chart_range')
+                                            ->label(__('settings/general.default_chart_range'))
+                                            ->native(false)
+                                            ->options([
+                                                '24h' => __('settings/general.default_chart_range_24h'),
+                                                'week' => __('settings/general.default_chart_range_week'),
+                                                'month' => __('settings/general.default_chart_range_month'),
+                                            ])
+                                            ->required(),
+                                    ]),
+                            ])
+                            ->columnSpanFull(),
+
+                        Tab::make(__('settings/general.data_retention'))
+                            ->icon(Heroicon::OutlinedTrash)
+                            ->schema([
+                                Grid::make(['default' => 1, 'md' => 2])
+                                    ->schema([
+                                        TextInput::make('prune_results_older_than')
+                                            ->label(__('settings/general.prune_results_older_than'))
+                                            ->hint(__('settings/general.prune_results_older_than_hint'))
+                                            ->helperText(__('settings/general.prune_results_older_than_helper_text'))
+                                            ->numeric()
+                                            ->minValue(0)
+                                            ->required(),
+                                    ]),
+                            ])
+                            ->columnSpanFull(),
+
+                        Tab::make(__('settings/general.connectivity'))
+                            ->icon(Heroicon::OutlinedWifi)
+                            ->schema([
+                                Grid::make(['default' => 1, 'md' => 2])
+                                    ->schema([
+                                        TextInput::make('speedtest_external_ip_url')
+                                            ->label(__('settings/general.speedtest_external_ip_url'))
+                                            ->helperText(__('settings/general.speedtest_external_ip_url_helper_text'))
+                                            ->url()
+                                            ->required(),
+                                        TextInput::make('speedtest_internet_check_hostname')
+                                            ->label(__('settings/general.speedtest_internet_check_hostname'))
+                                            ->helperText(__('settings/general.speedtest_internet_check_hostname_helper_text'))
+                                            ->required(),
+                                    ]),
+                            ])
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+            ]);
+    }
+}

--- a/app/Filament/Pages/Settings/General.php
+++ b/app/Filament/Pages/Settings/General.php
@@ -76,6 +76,23 @@ class General extends SettingsPage
                                                     ->openUrlInNewTab()
                                             )
                                             ->required(),
+                                    ]),
+                            ])
+                            ->columnSpanFull(),
+
+                        Tab::make(__('settings/general.charts'))
+                            ->icon(Heroicon::OutlinedChartBar)
+                            ->schema([
+                                Grid::make(['default' => 1, 'md' => 2])
+                                    ->schema([
+                                        Select::make('default_chart_range')
+                                            ->label(__('settings/general.default_chart_range'))
+                                            ->options([
+                                                '24h' => __('settings/general.default_chart_range_24h'),
+                                                'week' => __('settings/general.default_chart_range_week'),
+                                                'month' => __('settings/general.default_chart_range_month'),
+                                            ])
+                                            ->required(),
                                         TextInput::make('chart_datetime_format')
                                             ->label(__('settings/general.chart_datetime_format'))
                                             ->helperText(__('settings/general.chart_datetime_format_helper_text'))
@@ -90,24 +107,6 @@ class General extends SettingsPage
                                         Toggle::make('chart_begin_at_zero')
                                             ->label(__('settings/general.chart_begin_at_zero'))
                                             ->columnSpanFull(),
-                                    ]),
-                            ])
-                            ->columnSpanFull(),
-
-                        Tab::make(__('settings/general.charts'))
-                            ->icon(Heroicon::OutlinedChartBar)
-                            ->schema([
-                                Grid::make(['default' => 1, 'md' => 2])
-                                    ->schema([
-                                        Select::make('default_chart_range')
-                                            ->label(__('settings/general.default_chart_range'))
-                                            ->native(false)
-                                            ->options([
-                                                '24h' => __('settings/general.default_chart_range_24h'),
-                                                'week' => __('settings/general.default_chart_range_week'),
-                                                'month' => __('settings/general.default_chart_range_month'),
-                                            ])
-                                            ->required(),
                                     ]),
                             ])
                             ->columnSpanFull(),

--- a/app/Filament/Resources/ApiTokens/Tables/ApiTokenTable.php
+++ b/app/Filament/Resources/ApiTokens/Tables/ApiTokenTable.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ApiTokens\Tables;
 
+use App\Settings\GeneralSettings;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
@@ -29,22 +30,22 @@ class ApiTokenTable
                     ->badge(),
                 TextColumn::make('created_at')
                     ->label(__('general.created_at'))
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->toggleable(isToggledHiddenByDefault: false)
                     ->sortable()
                     ->alignEnd(),
                 TextColumn::make('last_used_at')
                     ->label(__('api_tokens.last_used_at'))
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->toggleable(isToggledHiddenByDefault: true)
                     ->sortable()
                     ->alignEnd(),
                 TextColumn::make('expires_at')
                     ->label(__('api_tokens.expires_at'))
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->toggleable(isToggledHiddenByDefault: false)
                     ->sortable()
                     ->alignEnd(),

--- a/app/Filament/Resources/Results/Schemas/ResultForm.php
+++ b/app/Filament/Resources/Results/Schemas/ResultForm.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\Results\Schemas;
 
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Carbon\Carbon;
 use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\Textarea;
@@ -31,8 +32,8 @@ class ResultForm
                                     ->label(__('general.created_at'))
                                     ->afterStateHydrated(function (TextInput $component, $state) {
                                         $component->state(Carbon::parse($state)
-                                            ->timezone(config('app.display_timezone'))
-                                            ->format(config('app.datetime_format')));
+                                            ->timezone(app(GeneralSettings::class)->display_timezone)
+                                            ->format(app(GeneralSettings::class)->datetime_format));
                                     }),
                                 TextInput::make('download')
                                     ->label(__('general.download'))

--- a/app/Filament/Resources/Results/Tables/ResultTable.php
+++ b/app/Filament/Resources/Results/Tables/ResultTable.php
@@ -7,6 +7,7 @@ use App\Filament\Exports\ResultExporter;
 use App\Filament\Tables\Columns\ResultServerColumn;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
@@ -120,8 +121,8 @@ class ResultTable
 
                 TextColumn::make('created_at')
                     ->label(__('general.created_at'))
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->toggleable(isToggledHiddenByDefault: false)
                     ->sortable(),
             ])

--- a/app/Filament/Resources/Users/Tables/UserTable.php
+++ b/app/Filament/Resources/Users/Tables/UserTable.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\Users\Tables;
 
 use App\Enums\UserRole;
+use App\Settings\GeneralSettings;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
@@ -35,15 +36,15 @@ class UserTable
                 TextColumn::make('created_at')
                     ->label(__('general.created_at'))
                     ->alignEnd()
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: false),
                 TextColumn::make('updated_at')
                     ->label(__('general.updated_at'))
                     ->alignEnd()
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true),
             ])

--- a/app/Filament/Resources/Webhooks/Tables/WebhookTable.php
+++ b/app/Filament/Resources/Webhooks/Tables/WebhookTable.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\Webhooks\Tables;
 use App\Actions\Notifications\SendWebhookTestNotification;
 use App\Enums\WebhookEvent;
 use App\Models\Webhook;
+use App\Settings\GeneralSettings;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\DeleteAction;
@@ -36,8 +37,8 @@ class WebhookTable
                 TextColumn::make('created_at')
                     ->label(__('general.created_at'))
                     ->alignEnd()
-                    ->dateTime(config('app.datetime_format'))
-                    ->timezone(config('app.display_timezone'))
+                    ->dateTime(app(GeneralSettings::class)->datetime_format)
+                    ->timezone(app(GeneralSettings::class)->display_timezone)
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: false),
             ])

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadChartWidget extends ChartWidget
@@ -30,7 +31,7 @@ class RecentDownloadChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -74,7 +75,7 @@ class RecentDownloadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -95,7 +96,7 @@ class RecentDownloadChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadLatencyChartWidget extends ChartWidget
@@ -28,7 +29,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -84,7 +85,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -104,7 +105,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentJitterChartWidget extends ChartWidget
@@ -28,7 +29,7 @@ class RecentJitterChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -84,7 +85,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -104,7 +105,7 @@ class RecentJitterChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -6,6 +6,7 @@ use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentPingChartWidget extends ChartWidget
@@ -29,7 +30,7 @@ class RecentPingChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -73,7 +74,7 @@ class RecentPingChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -93,7 +94,7 @@ class RecentPingChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadChartWidget extends ChartWidget
@@ -30,7 +31,7 @@ class RecentUploadChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -74,7 +75,7 @@ class RecentUploadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -94,7 +95,7 @@ class RecentUploadChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadLatencyChartWidget extends ChartWidget
@@ -28,7 +29,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
 
     public function mount(): void
     {
-        $this->filter = $this->filter ?? config('speedtest.default_chart_range', '24h');
+        $this->filter = $this->filter ?? app(GeneralSettings::class)->default_chart_range;
     }
 
     protected function getData(): array
@@ -84,7 +85,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(app(GeneralSettings::class)->display_timezone)->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -104,7 +105,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Http/Controllers/Api/V0/GetLatestController.php
+++ b/app/Http/Controllers/Api/V0/GetLatestController.php
@@ -6,6 +6,7 @@ use App\Enums\ResultStatus;
 use App\Helpers\Number;
 use App\Http\Controllers\Controller;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Illuminate\Http\JsonResponse;
 
 class GetLatestController extends Controller
@@ -39,8 +40,8 @@ class GetLatestController extends Controller
                 'url' => $latest->result_url,
                 'scheduled' => $latest->scheduled,
                 'failed' => $latest->status === ResultStatus::Failed,
-                'created_at' => $latest->created_at->timezone(config('app.display_timezone'))->toISOString(true),
-                'updated_at' => $latest->updated_at->timezone(config('app.display_timezone'))->toISOString(true),
+                'created_at' => $latest->created_at->timezone(app(GeneralSettings::class)->display_timezone)->toISOString(true),
+                'updated_at' => $latest->updated_at->timezone(app(GeneralSettings::class)->display_timezone)->toISOString(true),
             ],
         ]);
     }

--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -7,6 +7,7 @@ use App\Enums\ResultStatus;
 use App\Events\SpeedtestChecking;
 use App\Events\SpeedtestFailed;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -82,7 +83,7 @@ class CheckForInternetConnectionJob implements ShouldQueue
      */
     protected function httpFallbackSucceeds(): bool
     {
-        $url = config('speedtest.preflight.external_ip_url');
+        $url = app(GeneralSettings::class)->speedtest_external_ip_url;
 
         try {
             $response = Http::retry(3, 100)

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -46,7 +46,13 @@ class Result extends Model
      */
     public function prunable(): Builder
     {
-        return static::where('created_at', '<=', now()->subDays(app(GeneralSettings::class)->prune_results_older_than));
+        $days = app(GeneralSettings::class)->prune_results_older_than;
+
+        if ($days === 0) {
+            return static::query()->whereRaw('1 = 0');
+        }
+
+        return static::where('created_at', '<=', now()->subDays($days));
     }
 
     /**

--- a/app/Models/Result.php
+++ b/app/Models/Result.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\ResultService;
 use App\Enums\ResultStatus;
 use App\Models\Traits\ResultDataAttributes;
+use App\Settings\GeneralSettings;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -45,7 +46,7 @@ class Result extends Model
      */
     public function prunable(): Builder
     {
-        return static::where('created_at', '<=', now()->subDays(config('speedtest.prune_results_older_than')));
+        return static::where('created_at', '<=', now()->subDays(app(GeneralSettings::class)->prune_results_older_than));
     }
 
     /**

--- a/app/Services/ScheduledSpeedtestService.php
+++ b/app/Services/ScheduledSpeedtestService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Settings\GeneralSettings;
 use Carbon\Carbon;
 use Cron\CronExpression;
 
@@ -23,7 +24,7 @@ class ScheduledSpeedtestService
         $cronExpression = new CronExpression($schedule);
 
         return Carbon::parse(
-            time: $cronExpression->getNextRunDate(timeZone: config('app.display_timezone'))
+            time: $cronExpression->getNextRunDate(timeZone: app(GeneralSettings::class)->display_timezone)
         );
     }
 }

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class GeneralSettings extends Settings
+{
+    public string $default_chart_range;
+
+    public int $prune_results_older_than;
+
+    public string $datetime_format;
+
+    public string $chart_datetime_format;
+
+    public string $display_timezone;
+
+    public bool $chart_begin_at_zero;
+
+    public string $speedtest_external_ip_url;
+
+    public string $speedtest_internet_check_hostname;
+
+    public static function group(): string
+    {
+        return 'general';
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', 'UTC'),
+    'timezone' => env('APP_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------
@@ -151,7 +151,7 @@ return [
 
     'datetime_format' => env('DATETIME_FORMAT', 'M. j, Y g:ia'),
 
-    'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),
+    'display_timezone' => env('DISPLAY_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/settings/2026_06_28_000000_create_general_settings.php
+++ b/database/settings/2026_06_28_000000_create_general_settings.php
@@ -1,0 +1,18 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('general.default_chart_range', config('speedtest.default_chart_range'));
+        $this->migrator->add('general.prune_results_older_than', config('speedtest.prune_results_older_than'));
+        $this->migrator->add('general.datetime_format', config('app.datetime_format'));
+        $this->migrator->add('general.chart_datetime_format', config('app.chart_datetime_format'));
+        $this->migrator->add('general.display_timezone', config('app.display_timezone'));
+        $this->migrator->add('general.chart_begin_at_zero', config('app.chart_begin_at_zero'));
+        $this->migrator->add('general.speedtest_external_ip_url', config('speedtest.preflight.external_ip_url'));
+        $this->migrator->add('general.speedtest_internet_check_hostname', config('speedtest.preflight.internet_check_hostname'));
+    }
+};

--- a/lang/en/settings/general.php
+++ b/lang/en/settings/general.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'title' => 'General',
+    'label' => 'General',
+
+    // Display section
+    'display' => 'Display',
+    'display_timezone' => 'Timezone',
+    'display_timezone_helper_text' => 'The timezone used to display dates and times.',
+    'datetime_format' => 'Datetime format',
+    'datetime_format_helper_text' => 'The format used to display dates and times in tables and lists.',
+    'chart_datetime_format' => 'Chart datetime format',
+    'chart_datetime_format_helper_text' => 'The format used to display dates on chart axes.',
+    'datetime_format_docs' => 'Format options',
+    'chart_begin_at_zero' => 'Begin charts at zero',
+
+    // Charts section
+    'charts' => 'Charts',
+    'default_chart_range' => 'Default chart range',
+    'default_chart_range_24h' => 'Last 24 hours',
+    'default_chart_range_week' => 'Last week',
+    'default_chart_range_month' => 'Last month',
+
+    // Data retention section
+    'data_retention' => 'Data Retention',
+    'prune_results_older_than' => 'Prune results older than',
+    'prune_results_older_than_hint' => 'days',
+    'prune_results_older_than_helper_text' => 'Automatically delete results older than this many days. Set to 0 to disable.',
+
+    // Connectivity section
+    'connectivity' => 'Connectivity',
+    'speedtest_external_ip_url' => 'External IP URL',
+    'speedtest_external_ip_url_helper_text' => 'URL used to fetch the external IP address before running a speedtest.',
+    'speedtest_internet_check_hostname' => 'Internet check hostname',
+    'speedtest_internet_check_hostname_helper_text' => 'Hostname pinged to verify internet connectivity before running a speedtest.',
+];

--- a/resources/views/livewire/latest-result-stats.blade.php
+++ b/resources/views/livewire/latest-result-stats.blade.php
@@ -9,7 +9,7 @@
                             {{ __('general.last_results') }}
                         </h2>
 
-                        <p class="mt-1 text-sm font-medium text-zinc-600 dark:text-zinc-400">{{ $this->latestResult->created_at->timezone(config('app.display_timezone'))->format(config('app.datetime_format')) }}</p>
+                        <p class="mt-1 text-sm font-medium text-zinc-600 dark:text-zinc-400">{{ $this->latestResult->created_at->timezone(app(\App\Settings\GeneralSettings::class)->display_timezone)->format(app(\App\Settings\GeneralSettings::class)->datetime_format) }}</p>
                     </div>
 
                     @auth

--- a/resources/views/livewire/next-speedtest-banner.blade.php
+++ b/resources/views/livewire/next-speedtest-banner.blade.php
@@ -8,7 +8,7 @@
 
                 <div class="ml-3 flex-1">
                     <p class="text-sm text-blue-700 dark:text-blue-300">
-                        {{ __('dashboard.next_speedtest_at') }} <span class="font-medium">{{ $this->nextSpeedtest->timezone(config('app.display_timezone'))->format(config('app.datetime_format')) }}</span>.
+                        {{ __('dashboard.next_speedtest_at') }} <span class="font-medium">{{ $this->nextSpeedtest->timezone(app(\App\Settings\GeneralSettings::class)->display_timezone)->format(app(\App\Settings\GeneralSettings::class)->datetime_format) }}</span>.
                     </p>
                 </div>
             </div>

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,6 +2,7 @@
 
 use App\Actions\CheckForScheduledSpeedtests;
 use App\Actions\VacuumDatabase;
+use App\Settings\GeneralSettings;
 use Illuminate\Support\Facades\Schedule;
 
 /**
@@ -10,7 +11,7 @@ use Illuminate\Support\Facades\Schedule;
 Schedule::command('model:prune')
     ->daily()
     ->when(function () {
-        return config('speedtest.prune_results_older_than') > 0;
+        return app(GeneralSettings::class)->prune_results_older_than > 0;
     });
 
 /**

--- a/tests/Feature/GeneralSettingsTest.php
+++ b/tests/Feature/GeneralSettingsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Filament\Pages\Settings\General;
+use App\Models\User;
+use App\Settings\GeneralSettings;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->admin = User::factory()->create(['role' => UserRole::Admin]);
+    $this->user = User::factory()->create(['role' => UserRole::User]);
+});
+
+describe('access', function () {
+    it('renders for admin users', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->assertSuccessful();
+    });
+
+    it('denies access to non-admin users', function () {
+        $this->actingAs($this->user);
+
+        $this->get(General::getUrl())->assertForbidden();
+    });
+});
+
+describe('form', function () {
+    it('loads current settings into the form', function () {
+        $this->actingAs($this->admin);
+
+        $settings = app(GeneralSettings::class);
+
+        Livewire::test(General::class)
+            ->assertFormSet([
+                'display_timezone' => $settings->display_timezone,
+                'datetime_format' => $settings->datetime_format,
+                'chart_datetime_format' => $settings->chart_datetime_format,
+                'chart_begin_at_zero' => $settings->chart_begin_at_zero,
+                'default_chart_range' => $settings->default_chart_range,
+                'prune_results_older_than' => $settings->prune_results_older_than,
+                'speedtest_external_ip_url' => $settings->speedtest_external_ip_url,
+                'speedtest_internet_check_hostname' => $settings->speedtest_internet_check_hostname,
+            ]);
+    });
+
+    it('saves updated settings to the database', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'display_timezone' => 'Europe/Berlin',
+                'datetime_format' => 'd.m.Y H:i',
+                'chart_datetime_format' => 'd.m H:i',
+                'chart_begin_at_zero' => false,
+                'default_chart_range' => 'week',
+                'prune_results_older_than' => 30,
+                'speedtest_external_ip_url' => 'https://checkip.amazonaws.com',
+                'speedtest_internet_check_hostname' => 'checkip.amazonaws.com',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        app()->forgetInstance(GeneralSettings::class);
+        $settings = app(GeneralSettings::class);
+
+        expect($settings->display_timezone)->toBe('Europe/Berlin')
+            ->and($settings->datetime_format)->toBe('d.m.Y H:i')
+            ->and($settings->chart_datetime_format)->toBe('d.m H:i')
+            ->and($settings->chart_begin_at_zero)->toBeFalse()
+            ->and($settings->default_chart_range)->toBe('week')
+            ->and($settings->prune_results_older_than)->toBe(30)
+            ->and($settings->speedtest_external_ip_url)->toBe('https://checkip.amazonaws.com')
+            ->and($settings->speedtest_internet_check_hostname)->toBe('checkip.amazonaws.com');
+    });
+
+    it('requires all fields', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'display_timezone' => null,
+                'datetime_format' => null,
+                'chart_datetime_format' => null,
+                'default_chart_range' => null,
+                'prune_results_older_than' => null,
+                'speedtest_external_ip_url' => null,
+                'speedtest_internet_check_hostname' => null,
+            ])
+            ->call('save')
+            ->assertHasFormErrors([
+                'display_timezone' => 'required',
+                'datetime_format' => 'required',
+                'chart_datetime_format' => 'required',
+                'default_chart_range' => 'required',
+                'prune_results_older_than' => 'required',
+                'speedtest_external_ip_url' => 'required',
+                'speedtest_internet_check_hostname' => 'required',
+            ]);
+    });
+
+    it('validates the external ip url is a valid url', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm(['speedtest_external_ip_url' => 'not-a-url'])
+            ->call('save')
+            ->assertHasFormErrors(['speedtest_external_ip_url' => 'url']);
+    });
+
+    it('validates prune_results_older_than is numeric and at least 0', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm(['prune_results_older_than' => -1])
+            ->call('save')
+            ->assertHasFormErrors(['prune_results_older_than' => 'min']);
+    });
+});

--- a/tests/Unit/Services/ScheduledSpeedtestServiceTest.php
+++ b/tests/Unit/Services/ScheduledSpeedtestServiceTest.php
@@ -1,7 +1,11 @@
 <?php
 
 use App\Services\ScheduledSpeedtestService;
+use App\Settings\GeneralSettings;
 use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
 
 test('returns null when schedule config is null', function () {
     config()->set('speedtest.schedule', null);
@@ -37,7 +41,7 @@ test('returns Carbon instance when schedule is configured', function () {
 
 test('returns correct next scheduled time for hourly cron', function () {
     config()->set('speedtest.schedule', '0 * * * *'); // Every hour at minute 0
-    config()->set('app.display_timezone', 'UTC');
+    app(GeneralSettings::class)->fill(['display_timezone' => 'UTC'])->save();
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -47,7 +51,7 @@ test('returns correct next scheduled time for hourly cron', function () {
 
 test('returns correct next scheduled time for daily cron', function () {
     config()->set('speedtest.schedule', '0 0 * * *'); // Every day at midnight
-    config()->set('app.display_timezone', 'UTC');
+    app(GeneralSettings::class)->fill(['display_timezone' => 'UTC'])->save();
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -58,7 +62,7 @@ test('returns correct next scheduled time for daily cron', function () {
 
 test('returns future date for next scheduled test', function () {
     config()->set('speedtest.schedule', '*/5 * * * *'); // Every 5 minutes
-    config()->set('app.display_timezone', 'UTC');
+    app(GeneralSettings::class)->fill(['display_timezone' => 'UTC'])->save();
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 


### PR DESCRIPTION
## 📃 Description

Adds a General Settings page to the admin panel, allowing admins to configure display, chart, data retention, and connectivity settings at runtime without editing `.env` or restarting the application.

## 🪵 Changelog

### ➕ Added

- General Settings page under `Settings > General` with four tabs: Display, Charts, Data Retention, and Connectivity
- Settings are now stored in the database and managed through the admin UI

### ✏️ Changed

- Timezone, date formats, chart defaults, data pruning rules, and preflight hostnames are now configurable via the UI instead of environment variables

## 📷 Screenshots

<img width="1295" height="414" alt="Scherm­afbeelding 2026-06-28 om 14 35 05" src="https://github.com/user-attachments/assets/55441a11-ce55-4268-a614-8a2975e1724f" />

