### PR TITLE
Uniform time x-axis

### DIFF
--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -74,7 +74,7 @@ class RecentDownloadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -98,6 +98,17 @@ class RecentDownloadChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -84,7 +84,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -106,6 +106,17 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
+                ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -84,7 +84,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -105,7 +105,19 @@ class RecentJitterChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -73,7 +73,7 @@ class RecentPingChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -96,6 +96,17 @@ class RecentPingChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -74,7 +74,7 @@ class RecentUploadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -97,6 +97,17 @@ class RecentUploadChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -84,7 +84,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -107,6 +107,17 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }


### PR DESCRIPTION
## 📃 Description

The x-axis for all widgets now uses the test result's created_at attribute instead of uniformly distributing test results across available space.

Adding multiple manual tests will no longer skew data presentation.


## 🪵 Changelog

### ➕ Added

- added explicit x-axis definition to each widgets `getOptions()` method.


## 📷 Screenshots

<img width="1255" height="750" alt="image" src="https://github.com/user-attachments/assets/8cbc626b-b12b-4edb-94cc-7322d31ac9c8" />


