### PR TITLE
[Feat] Chart spanning missing data

### DIFF
--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadChartWidget extends ChartWidget
@@ -80,7 +81,16 @@ class RecentDownloadChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.5 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -74,7 +74,7 @@ class RecentDownloadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -98,6 +98,17 @@ class RecentDownloadChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadLatencyChartWidget extends ChartWidget
@@ -90,7 +91,16 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.25 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -84,7 +84,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -106,6 +106,17 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
+                ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentJitterChartWidget extends ChartWidget
@@ -90,7 +91,16 @@ class RecentJitterChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.25 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -84,7 +84,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -105,7 +105,19 @@ class RecentJitterChartWidget extends ChartWidget
             'scales' => [
                 'y' => [
                     'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -73,7 +73,7 @@ class RecentPingChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -96,6 +96,17 @@ class RecentPingChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -6,6 +6,7 @@ use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentPingChartWidget extends ChartWidget
@@ -79,7 +80,16 @@ class RecentPingChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.25 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadChartWidget extends ChartWidget
@@ -80,7 +81,16 @@ class RecentUploadChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.25 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -74,7 +74,7 @@ class RecentUploadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -97,6 +97,17 @@ class RecentUploadChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -84,7 +84,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->timestamp * 1_000),
         ];
     }
 
@@ -107,6 +107,17 @@ class RecentUploadLatencyChartWidget extends ChartWidget
                     'beginAtZero' => config('app.chart_begin_at_zero'),
                     'grace' => 2,
                 ],
+                'x' => [
+                    'type' => 'time',
+                    'time' => [
+                        'round' => 'minute',
+                        'displayFormats' => [
+                            'hour' => 'MMM d - HH:MM'
+                        ],
+                        'unit' => 'hour',
+                    ],
+                    'max' => now(config('app.display_timezone'))->timestamp * 1_000,
+                ]
             ],
         ];
     }

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Services\ScheduledSpeedtestService;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadLatencyChartWidget extends ChartWidget
@@ -90,7 +91,16 @@ class RecentUploadLatencyChartWidget extends ChartWidget
 
     protected function getOptions(): array
     {
+        $gapSize = config('app.chart_max_span_size');
+        if (is_null($gapSize)) {
+            $gapSize = 1.25 * ScheduledSpeedtestService::getScheduleInterval()->totalSeconds * 1_000;
+        }
+        elseif (is_int($gapSize)) {
+            $gapSize = $gapSize * 1_000;
+        }
+
         return [
+            'spanGaps' => $gapSize,
             'plugins' => [
                 'legend' => [
                     'display' => true,

--- a/app/Services/ScheduledSpeedtestService.php
+++ b/app/Services/ScheduledSpeedtestService.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use Carbon\Carbon;
+use Carbon\CarbonInterval;
 use Cron\CronExpression;
 
 class ScheduledSpeedtestService
@@ -25,5 +26,25 @@ class ScheduledSpeedtestService
         return Carbon::parse(
             time: $cronExpression->getNextRunDate(timeZone: config('app.display_timezone'))
         );
+    }
+
+    public static function getScheduleInterval(): ?CarbonInterval
+    {
+        $schedule = config('speedtest.schedule');
+
+        if (blank($schedule) || $schedule === false) {
+            return null;
+        }
+
+        $cronExpression = new CronExpression($schedule);
+
+        $prev = Carbon::parse(
+            time: $cronExpression->getPreviousRunDate(timeZone: config('app.display_timezone'))
+        );
+        $next = Carbon::parse(
+            time: $cronExpression->getNextRunDate(timeZone: config('app.display_timezone'))
+        );
+
+        return $prev->diff($next, true);
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -140,6 +140,10 @@ return [
 
     'chart_datetime_format' => env('CHART_DATETIME_FORMAT', 'M. j - G:i'),
 
+    // Span gaps shorter than this in chart data. Typically caused by failed or missed tests.
+    // When Null, will attempt to calculated test schedule from cron.
+    'chart_max_span_size' => env('CHART_MAX_SPAN_SIZE', NULL),
+
     /*
     |--------------------------------------------------------------------------
     | Display Configuration


### PR DESCRIPTION
## 📃 Description

Auto detect gaps in test data results and display the gaps in each metric widget. Allows the user to quickly see missing or failed tests. 

<img width="1251" height="760" alt="Time Axis" src="https://github.com/user-attachments/assets/19bcfda6-ddb9-4b8e-95da-4315055d8d17" />

Requires [pull #2835 Time X-axis](https://github.com/alexjustesen/speedtest-tracker/pull/2835#issue-4920560925)

## 📖 Documentation

[Documentation Pull #115](https://github.com/alexjustesen/speedtest-tracker-docs/pull/115#issue-4920646851)

## 🪵 Changelog

### ➕ Added 

- optional `CHART_MAX_SPAN_SIZE ` environment variable to control what chartJs considers a gap in the test-result data.
- `ScheduledSpeedtestService` public method `getScheduleInterval()` to calculate time between scheduled cron jobs.


## 📷 Screenshots


