### PR TITLE
[Feat] Implement issue #1565 - multiple cron schedules

### DIFF
--- a/app/Actions/CheckForScheduledSpeedtests.php
+++ b/app/Actions/CheckForScheduledSpeedtests.php
@@ -4,6 +4,7 @@ namespace App\Actions;
 
 use App\Actions\Ookla\RunSpeedtest;
 use Cron\CronExpression;
+use Illuminate\Support\Collection;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class CheckForScheduledSpeedtests
@@ -14,10 +15,6 @@ class CheckForScheduledSpeedtests
     {
         $schedule = config('speedtest.schedule');
 
-        if (blank($schedule) || $schedule === false) {
-            return;
-        }
-
         RunSpeedtest::runIf(
             $this->isSpeedtestDue(schedule: $schedule),
             scheduled: true,
@@ -27,13 +24,10 @@ class CheckForScheduledSpeedtests
     /**
      * Assess if a speedtest is due to run based on the schedule.
      */
-    private function isSpeedtestDue(string $schedule): bool
+    private function isSpeedtestDue(Collection $schedule): bool
     {
-        $cron = new CronExpression($schedule);
-
-        return $cron->isDue(
-            currentTime: now(),
-            timeZone: config('app.display_timezone')
-        );
+        return $schedule->map(fn ($expression) => new CronExpression($expression))
+            ->filter(fn ($cron) => $cron->isDue(currentTime: now(), timeZone: config('app.display_timezone')))
+            ->isNotEmpty();
     }
 }

--- a/app/Services/ScheduledSpeedtestService.php
+++ b/app/Services/ScheduledSpeedtestService.php
@@ -16,14 +16,9 @@ class ScheduledSpeedtestService
     {
         $schedule = config('speedtest.schedule');
 
-        if (blank($schedule) || $schedule === false) {
-            return null;
-        }
-
-        $cronExpression = new CronExpression($schedule);
-
-        return Carbon::parse(
-            time: $cronExpression->getNextRunDate(timeZone: config('app.display_timezone'))
-        );
+        return $schedule
+            ->map(fn ($expression) => Carbon::parse(time: (new CronExpression($expression))->getNextRunDate(timeZone: config('app.display_timezone'))))
+            ->sort()
+            ->first();
     }
 }

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Carbon\Carbon;
+use Illuminate\Support\Str;
 
 return [
     /**
@@ -21,7 +22,10 @@ return [
     /**
      * Speedtest settings.
      */
-    'schedule' => env('SPEEDTEST_SCHEDULE', false),
+    'schedule' => match(env('SPEEDTEST_SCHEDULE')) {
+        null, false => collect(),
+        default => Str::of(env('SPEEDTEST_SCHEDULE'))->split('/\s*[|]\s*/')->unique()
+    },
 
     'servers' => env('SPEEDTEST_SERVERS'),
 

--- a/tests/Unit/Services/ScheduledSpeedtestServiceTest.php
+++ b/tests/Unit/Services/ScheduledSpeedtestServiceTest.php
@@ -4,7 +4,7 @@ use App\Services\ScheduledSpeedtestService;
 use Carbon\Carbon;
 
 test('returns null when schedule config is null', function () {
-    config()->set('speedtest.schedule', null);
+    config()->set('speedtest.schedule', collect());
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -12,7 +12,7 @@ test('returns null when schedule config is null', function () {
 });
 
 test('returns null when schedule config is false', function () {
-    config()->set('speedtest.schedule', false);
+    config()->set('speedtest.schedule', collect());
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -20,7 +20,7 @@ test('returns null when schedule config is false', function () {
 });
 
 test('returns null when schedule config is blank string', function () {
-    config()->set('speedtest.schedule', '');
+    config()->set('speedtest.schedule', collect());
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -28,7 +28,15 @@ test('returns null when schedule config is blank string', function () {
 });
 
 test('returns Carbon instance when schedule is configured', function () {
-    config()->set('speedtest.schedule', '*/5 * * * *'); // Every 5 minutes
+    config()->set('speedtest.schedule', collect(['*/5 * * * *'])); // Every 5 minutes
+
+    $result = ScheduledSpeedtestService::getNextScheduledTest();
+
+    expect($result)->toBeInstanceOf(Carbon::class);
+});
+
+test('returns Carbon instance when schedule is configured with multiple values', function () {
+    config()->set('speedtest.schedule', collect(['*/5 * * * *', '*/12 * * * *'])); // Every 5 minutes
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
 
@@ -36,7 +44,7 @@ test('returns Carbon instance when schedule is configured', function () {
 });
 
 test('returns correct next scheduled time for hourly cron', function () {
-    config()->set('speedtest.schedule', '0 * * * *'); // Every hour at minute 0
+    config()->set('speedtest.schedule', collect(['0 * * * *'])); // Every hour at minute 0
     config()->set('app.display_timezone', 'UTC');
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
@@ -46,7 +54,7 @@ test('returns correct next scheduled time for hourly cron', function () {
 });
 
 test('returns correct next scheduled time for daily cron', function () {
-    config()->set('speedtest.schedule', '0 0 * * *'); // Every day at midnight
+    config()->set('speedtest.schedule', collect(['0 0 * * *'])); // Every day at midnight
     config()->set('app.display_timezone', 'UTC');
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();
@@ -57,7 +65,7 @@ test('returns correct next scheduled time for daily cron', function () {
 });
 
 test('returns future date for next scheduled test', function () {
-    config()->set('speedtest.schedule', '*/5 * * * *'); // Every 5 minutes
+    config()->set('speedtest.schedule', collect(['*/5 * * * *'])); // Every 5 minutes
     config()->set('app.display_timezone', 'UTC');
 
     $result = ScheduledSpeedtestService::getNextScheduledTest();


### PR DESCRIPTION
## 📃 Description

Expands the environment variable `SPEEDTEST_SCHEDULE` to allow pipe `|` separated cron expressions.

## 📖 Documentation

Add a link to the [PR #116](https://github.com/alexjustesen/speedtest-tracker-docs/pull/116) for documentation changes.

## 🪵 Changelog


### ✏️ Changed

- Updated CheckForScheduledSpeedtests and ScheduledSpeedtestService to expect multiple cron expressions.

