### PR TITLE
feat: add /about endpoint to retrieve application information

### DIFF
--- a/app/Http/Controllers/Api/V1/AboutController.php
+++ b/app/Http/Controllers/Api/V1/AboutController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1;
+
+use Illuminate\Http\Request;
+
+class AboutController extends ApiController
+{
+    /**
+     * GET /api/v1/about
+     * Return application information including name, build version and build date.
+     */
+    public function __invoke(Request $request)
+    {
+        return $this->sendResponse(
+            data: [
+                'name' => config('app.name'),
+                'build_version' => config('speedtest.build_version'),
+                'build_date' => config('speedtest.build_date')?->toDateString(),
+            ]
+        );
+    }
+}

--- a/app/OpenApi/Annotations/V1/AboutAnnotations.php
+++ b/app/OpenApi/Annotations/V1/AboutAnnotations.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\OpenApi\Annotations\V1;
+
+use Illuminate\Http\Response;
+use OpenApi\Attributes as OA;
+
+#[OA\PathItem(
+    path: '/api/v1/about',
+    description: 'Endpoint for retrieving application information.'
+)]
+class AboutAnnotations
+{
+    #[OA\Get(
+        path: '/api/v1/about',
+        summary: 'Retrieve application information',
+        description: 'Returns the application name, build version and build date. Requires an authenticated API token.',
+        operationId: 'getAbout',
+        tags: ['About'],
+        parameters: [
+            new OA\Parameter(ref: '#/components/parameters/AcceptHeader'),
+        ],
+        responses: [
+            new OA\Response(
+                response: Response::HTTP_OK,
+                description: 'Application information retrieved successfully',
+                content: new OA\JsonContent(
+                    properties: [
+                        new OA\Property(
+                            property: 'data',
+                            properties: [
+                                new OA\Property(property: 'name', type: 'string', example: 'Speedtest Tracker'),
+                                new OA\Property(property: 'build_version', type: 'string', example: 'v1.14.3'),
+                                new OA\Property(property: 'build_date', type: 'string', format: 'date', example: '2026-05-25'),
+                            ],
+                            type: 'object'
+                        ),
+                        new OA\Property(property: 'message', type: 'string', example: 'ok'),
+                    ],
+                    type: 'object'
+                )
+            ),
+            new OA\Response(
+                response: Response::HTTP_UNAUTHORIZED,
+                description: 'Unauthenticated',
+                content: new OA\JsonContent(ref: '#/components/schemas/UnauthenticatedError')
+            ),
+            new OA\Response(
+                response: Response::HTTP_NOT_ACCEPTABLE,
+                description: 'Not Acceptable - Missing or invalid Accept header',
+                content: new OA\JsonContent(ref: '#/components/schemas/NotAcceptableError')
+            ),
+        ]
+    )]
+    public function about(): void {}
+}

--- a/app/OpenApi/OpenApiDefinition.php
+++ b/app/OpenApi/OpenApiDefinition.php
@@ -42,6 +42,10 @@ use OpenApi\Attributes as OA;
             name: 'Stats',
             description: 'Endpoints for retrieving aggregated statistics and performance metrics. Requires `speedtests:read` token scope.'
         ),
+        new OA\Tag(
+            name: 'About',
+            description: 'Endpoint for retrieving application information. Requires an authenticated API token.'
+        ),
     ]
 )]
 class OpenApiDefinition {}

--- a/openapi.json
+++ b/openapi.json
@@ -5,6 +5,78 @@
         "version": "1.0.0"
     },
     "paths": {
+        "/api/v1/about": {
+            "description": "Endpoint for retrieving application information.",
+            "get": {
+                "tags": [
+                    "About"
+                ],
+                "summary": "Retrieve application information",
+                "description": "Returns the application name, build version and build date. Requires an authenticated API token.",
+                "operationId": "getAbout",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/AcceptHeader"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Application information retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "data": {
+                                            "properties": {
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "Speedtest Tracker"
+                                                },
+                                                "build_version": {
+                                                    "type": "string",
+                                                    "example": "v1.14.3"
+                                                },
+                                                "build_date": {
+                                                    "type": "string",
+                                                    "format": "date",
+                                                    "example": "2026-05-25"
+                                                }
+                                            },
+                                            "type": "object"
+                                        },
+                                        "message": {
+                                            "type": "string",
+                                            "example": "ok"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthenticated",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UnauthenticatedError"
+                                }
+                            }
+                        }
+                    },
+                    "406": {
+                        "description": "Not Acceptable - Missing or invalid Accept header",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/NotAcceptableError"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/ookla": {
             "description": "Endpoints for retrieving Ookla speedtest servers and related resources."
         },
@@ -1180,6 +1252,10 @@
         {
             "name": "Stats",
             "description": "Endpoints for retrieving aggregated statistics and performance metrics. Requires `speedtests:read` token scope."
+        },
+        {
+            "name": "About",
+            "description": "Endpoint for retrieving application information. Requires an authenticated API token."
         },
         {
             "name": "Servers",

--- a/routes/api/v1/routes.php
+++ b/routes/api/v1/routes.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\V1\AboutController;
 use App\Http\Controllers\Api\V1\OoklaController;
 use App\Http\Controllers\Api\V1\ResultsController;
 use App\Http\Controllers\Api\V1\SpeedtestController;
@@ -7,6 +8,9 @@ use App\Http\Controllers\Api\V1\StatsController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->name('api.v1.')->group(function () {
+    Route::get('/about', AboutController::class)
+        ->name('about');
+
     Route::get('/results', [ResultsController::class, 'list'])
         ->name('results.list');
 

--- a/tests/Feature/Api/AboutEndpointTest.php
+++ b/tests/Feature/Api/AboutEndpointTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+describe('about endpoint', function () {
+    test('requires authentication', function () {
+        $response = $this->getJson(route('api.v1.about'));
+
+        $response->assertUnauthorized();
+    });
+
+    test('returns application information for an authenticated token', function () {
+        config()->set('app.name', 'Speedtest Tracker');
+        config()->set('speedtest.build_version', 'v1.14.3');
+        config()->set('speedtest.build_date', Carbon\Carbon::parse('2026-05-25'));
+
+        Sanctum::actingAs(User::factory()->create());
+
+        $response = $this->getJson(route('api.v1.about'));
+
+        $response->assertOk()
+            ->assertJson([
+                'data' => [
+                    'name' => 'Speedtest Tracker',
+                    'build_version' => 'v1.14.3',
+                    'build_date' => '2026-05-25',
+                ],
+                'message' => 'ok',
+            ]);
+    });
+});


### PR DESCRIPTION
## 📃 Description

closes #2701 

```
{"data":{"name":"Speedtest Tracker","build_version":"v1.14.3","build_date":"2026-05-25"},"message":"ok"}
```