### PR TITLE
fix: make API start_at/end_at date filtering intuitive

### DIFF
--- a/app/Http/Controllers/Api/V1/ApiController.php
+++ b/app/Http/Controllers/Api/V1/ApiController.php
@@ -2,13 +2,46 @@
 
 namespace App\Http\Controllers\Api\V1;
 
+use Carbon\Carbon;
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Log;
+use Spatie\QueryBuilder\AllowedFilter;
+use Spatie\QueryBuilder\Enums\FilterOperator;
 
 abstract class ApiController
 {
+    /**
+     * Date-range filters aliasing a timestamp column.
+     *
+     * start_at -> column >= value (start of day for date-only input)
+     * end_at   -> column <= value (end of day for date-only input)
+     *
+     * @return array<int, AllowedFilter>
+     */
+    protected function dateRangeFilters(string $column = 'created_at'): array
+    {
+        return [
+            AllowedFilter::operator(
+                name: 'start_at',
+                filterOperator: FilterOperator::GREATER_THAN_OR_EQUAL,
+                internalName: $column,
+            ),
+            AllowedFilter::callback('end_at', function (Builder $query, $value) use ($column) {
+                $date = Carbon::parse($value);
+
+                // Date-only input (no time component) should include the whole day.
+                if (is_string($value) && ! str_contains($value, ':')) {
+                    $date->endOfDay();
+                }
+
+                $query->where($query->qualifyColumn($column), '<=', $date);
+            }),
+        ];
+    }
+
     /**
      * Send a response.
      *

--- a/app/Http/Controllers/Api/V1/ResultsController.php
+++ b/app/Http/Controllers/Api/V1/ResultsController.php
@@ -29,6 +29,8 @@ class ResultsController extends ApiController
         }
         $validator = Validator::make($request->all(), [
             'page.size' => 'integer|min:1|max:'.config('json-api-paginate.max_results'),
+            'filter.start_at' => 'sometimes|date',
+            'filter.end_at' => 'sometimes|date',
         ]);
 
         if ($validator->fails()) {
@@ -47,16 +49,7 @@ class ResultsController extends ApiController
                 AllowedFilter::exact('healthy')->nullable(),
                 AllowedFilter::exact('status'),
                 AllowedFilter::exact('scheduled'),
-                AllowedFilter::operator(
-                    name: 'start_at',
-                    internalName: 'created_at',
-                    filterOperator: FilterOperator::DYNAMIC,
-                ),
-                AllowedFilter::operator(
-                    name: 'end_at',
-                    internalName: 'created_at',
-                    filterOperator: FilterOperator::DYNAMIC,
-                ),
+                ...$this->dateRangeFilters(),
             ])
             ->allowedSorts([
                 'ping',

--- a/app/Http/Controllers/Api/V1/StatsController.php
+++ b/app/Http/Controllers/Api/V1/StatsController.php
@@ -6,8 +6,7 @@ use App\Http\Resources\V1\StatResource;
 use App\Models\Result;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
-use Spatie\QueryBuilder\AllowedFilter;
-use Spatie\QueryBuilder\Enums\FilterOperator;
+use Illuminate\Support\Facades\Validator;
 use Spatie\QueryBuilder\QueryBuilder;
 
 class StatsController extends ApiController
@@ -26,6 +25,19 @@ class StatsController extends ApiController
             );
         }
 
+        $validator = Validator::make($request->all(), [
+            'filter.start_at' => 'sometimes|date',
+            'filter.end_at' => 'sometimes|date',
+        ]);
+
+        if ($validator->fails()) {
+            return $this->sendResponse(
+                data: $validator->errors(),
+                message: 'Validation failed.',
+                code: 422
+            );
+        }
+
         // Build the stats query
         $stats = QueryBuilder::for(Result::class)
             ->selectRaw('count(*) as total_results')
@@ -38,10 +50,7 @@ class StatsController extends ApiController
             ->selectRaw('max(ping) as max_ping')
             ->selectRaw('max(download) as max_download')
             ->selectRaw('max(upload) as max_upload')
-            ->allowedFilters([
-                AllowedFilter::operator(name: 'start_at', internalName: 'created_at', filterOperator: FilterOperator::DYNAMIC),
-                AllowedFilter::operator(name: 'end_at', internalName: 'created_at', filterOperator: FilterOperator::DYNAMIC),
-            ])
+            ->allowedFilters($this->dateRangeFilters())
             ->first();
 
         // Return wrapped in a resource

--- a/app/OpenApi/Annotations/V1/ResultsAnnotations.php
+++ b/app/OpenApi/Annotations/V1/ResultsAnnotations.php
@@ -79,7 +79,7 @@ class ResultsAnnotations
                 in: 'query',
                 required: false,
                 schema: new OA\Schema(type: 'string', format: 'date'),
-                description: 'Filter results created on or before this date (alias for created_at<=)'
+                description: 'Filter results created on or before this date (alias for created_at<=). A date without a time includes the entire day.'
             ),
             new OA\Parameter(
                 name: 'sort',

--- a/app/OpenApi/Annotations/V1/StatsAnnotations.php
+++ b/app/OpenApi/Annotations/V1/StatsAnnotations.php
@@ -19,16 +19,16 @@ class StatsAnnotations
         parameters: [
             new OA\Parameter(ref: '#/components/parameters/AcceptHeader'),
             new OA\Parameter(
-                name: 'start_at',
+                name: 'filter[start_at]',
                 in: 'query',
-                description: 'Filter stats from this date/time (ISO 8601)',
+                description: 'Filter stats created on or after this date/time (alias for created_at>=)',
                 required: false,
                 schema: new OA\Schema(type: 'string', format: 'date-time')
             ),
             new OA\Parameter(
-                name: 'end_at',
+                name: 'filter[end_at]',
                 in: 'query',
-                description: 'Filter stats up to this date/time (ISO 8601)',
+                description: 'Filter stats created on or before this date/time (alias for created_at<=). A date without a time includes the entire day.',
                 required: false,
                 schema: new OA\Schema(type: 'string', format: 'date-time')
             ),

--- a/openapi.json
+++ b/openapi.json
@@ -99,7 +99,7 @@
                     {
                         "name": "filter[end_at]",
                         "in": "query",
-                        "description": "Filter results created on or before this date (alias for created_at<=)",
+                        "description": "Filter results created on or before this date (alias for created_at<=). A date without a time includes the entire day.",
                         "required": false,
                         "schema": {
                             "type": "string",
@@ -195,9 +195,9 @@
                         "$ref": "#/components/parameters/AcceptHeader"
                     },
                     {
-                        "name": "start_at",
+                        "name": "filter[start_at]",
                         "in": "query",
-                        "description": "Filter stats from this date/time (ISO 8601)",
+                        "description": "Filter stats created on or after this date/time (alias for created_at>=)",
                         "required": false,
                         "schema": {
                             "type": "string",
@@ -205,9 +205,9 @@
                         }
                     },
                     {
-                        "name": "end_at",
+                        "name": "filter[end_at]",
                         "in": "query",
-                        "description": "Filter stats up to this date/time (ISO 8601)",
+                        "description": "Filter stats created on or before this date/time (alias for created_at<=). A date without a time includes the entire day.",
                         "required": false,
                         "schema": {
                             "type": "string",

--- a/tests/Feature/Api/V1/ResultsFilterTest.php
+++ b/tests/Feature/Api/V1/ResultsFilterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Models\Result;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    Sanctum::actingAs(User::factory()->create(), ['results:read']);
+});
+
+test('filter[start_at] returns only results on or after the start of that day', function () {
+    $before = Result::factory()->create(['created_at' => '2025-12-31 23:00:00']);
+    $onDay = Result::factory()->create(['created_at' => '2026-01-01 00:30:00']);
+    $after = Result::factory()->create(['created_at' => '2026-01-02 10:00:00']);
+
+    $response = $this->getJson('/api/v1/results?filter[start_at]=2026-01-01');
+
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($onDay->id, $after->id)
+        ->not->toContain($before->id);
+});
+
+test('filter[end_at] with a date-only value includes results from the entire end day', function () {
+    $sameDayAfternoon = Result::factory()->create(['created_at' => '2026-01-31 15:00:00']);
+    $nextDay = Result::factory()->create(['created_at' => '2026-02-01 00:10:00']);
+
+    $response = $this->getJson('/api/v1/results?filter[end_at]=2026-01-31');
+
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($sameDayAfternoon->id)
+        ->not->toContain($nextDay->id);
+});
+
+test('combined start_at and end_at return the inclusive range', function () {
+    $before = Result::factory()->create(['created_at' => '2025-12-31 12:00:00']);
+    $inRangeStart = Result::factory()->create(['created_at' => '2026-01-01 00:00:00']);
+    $inRangeEnd = Result::factory()->create(['created_at' => '2026-01-31 23:30:00']);
+    $after = Result::factory()->create(['created_at' => '2026-02-01 08:00:00']);
+
+    $response = $this->getJson('/api/v1/results?filter[start_at]=2026-01-01&filter[end_at]=2026-01-31');
+
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($inRangeStart->id, $inRangeEnd->id)
+        ->not->toContain($before->id, $after->id);
+});
+
+test('filter[end_at] with an explicit time is honored literally', function () {
+    $beforeCutoff = Result::factory()->create(['created_at' => '2026-01-31 11:00:00']);
+    $afterCutoff = Result::factory()->create(['created_at' => '2026-01-31 15:00:00']);
+
+    $response = $this->getJson('/api/v1/results?filter[end_at]=2026-01-31 12:00:00');
+
+    $ids = collect($response->json('data'))->pluck('id');
+
+    expect($ids)->toContain($beforeCutoff->id)
+        ->not->toContain($afterCutoff->id);
+});
+
+test('an invalid date filter returns a 422', function () {
+    $response = $this->getJson('/api/v1/results?filter[start_at]=not-a-date');
+
+    $response->assertStatus(422);
+});

--- a/tests/Feature/Api/V1/StatsFilterTest.php
+++ b/tests/Feature/Api/V1/StatsFilterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use App\Models\Result;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+beforeEach(function () {
+    Sanctum::actingAs(User::factory()->create(), ['results:read']);
+});
+
+test('stats aggregate only counts results within the start/end range', function () {
+    Result::factory()->create(['created_at' => '2025-12-31 12:00:00']);
+    Result::factory()->create(['created_at' => '2026-01-01 09:00:00']);
+    Result::factory()->create(['created_at' => '2026-01-31 15:00:00']);
+    Result::factory()->create(['created_at' => '2026-02-01 08:00:00']);
+
+    $response = $this->getJson('/api/v1/stats?filter[start_at]=2026-01-01&filter[end_at]=2026-01-31');
+
+    $response->assertOk();
+
+    expect($response->json('data.total_results'))->toBe(2);
+});
+
+test('stats endpoint rejects an invalid date filter with a 422', function () {
+    $response = $this->getJson('/api/v1/stats?filter[end_at]=not-a-date');
+
+    $response->assertStatus(422);
+});


### PR DESCRIPTION
## 📃 Description

closes #2713 