### PR TITLE
feat: add nettest as a speedtest service

### DIFF
--- a/app/Actions/CheckForScheduledSpeedtests.php
+++ b/app/Actions/CheckForScheduledSpeedtests.php
@@ -2,7 +2,6 @@
 
 namespace App\Actions;
 
-use App\Actions\Ookla\RunSpeedtest;
 use Cron\CronExpression;
 use Lorisleiva\Actions\Concerns\AsAction;
 
@@ -18,7 +17,7 @@ class CheckForScheduledSpeedtests
             return;
         }
 
-        RunSpeedtest::runIf(
+        DispatchSpeedtest::runIf(
             $this->isSpeedtestDue(schedule: $schedule),
             scheduled: true,
         );

--- a/app/Actions/DispatchSpeedtest.php
+++ b/app/Actions/DispatchSpeedtest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Actions;
+
+use App\Enums\ResultService;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class DispatchSpeedtest
+{
+    use AsAction;
+
+    /**
+     * Runs a speedtest with the configured service.
+     */
+    public function handle(bool $scheduled = false, ?int $serverId = null, ?int $dispatchedBy = null): mixed
+    {
+        if (self::service() === ResultService::Nettest) {
+            return Nettest\RunSpeedtest::run(
+                scheduled: $scheduled,
+                serverId: $serverId,
+                dispatchedBy: $dispatchedBy,
+            );
+        }
+
+        return Ookla\RunSpeedtest::run(
+            scheduled: $scheduled,
+            serverId: $serverId,
+            dispatchedBy: $dispatchedBy,
+        );
+    }
+
+    /**
+     * Gets the configured service, falling back to Ookla.
+     */
+    public static function service(): ResultService
+    {
+        return ResultService::tryFrom((string) config('speedtest.service')) ?? ResultService::Ookla;
+    }
+}

--- a/app/Actions/Nettest/RunSpeedtest.php
+++ b/app/Actions/Nettest/RunSpeedtest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Nettest;
+
+use App\Enums\ResultService;
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestWaiting;
+use App\Jobs\CheckForInternetConnectionJob;
+use App\Jobs\Nettest\CompleteSpeedtestJob;
+use App\Jobs\Nettest\RunSpeedtestJob;
+use App\Jobs\Nettest\StartSpeedtestJob;
+use App\Models\Result;
+use Illuminate\Bus\Batch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Log;
+use Lorisleiva\Actions\Concerns\AsAction;
+use Throwable;
+
+class RunSpeedtest
+{
+    use AsAction;
+
+    /**
+     * Runs a speedtest with the Nettest CLI.
+     *
+     * The server is taken from the configuration because Nettest has no public
+     * server list, so a server ID has no meaning here and is ignored.
+     */
+    public function handle(bool $scheduled = false, ?int $serverId = null, ?int $dispatchedBy = null): mixed
+    {
+        $result = Result::create([
+            'service' => ResultService::Nettest,
+            'status' => ResultStatus::Waiting,
+            'scheduled' => $scheduled,
+            'dispatched_by' => $dispatchedBy,
+        ]);
+
+        SpeedtestWaiting::dispatch($result);
+
+        Bus::batch([
+            [
+                new StartSpeedtestJob($result),
+                new CheckForInternetConnectionJob($result),
+                new RunSpeedtestJob($result),
+                new CompleteSpeedtestJob($result),
+            ],
+        ])->catch(function (Batch $batch, ?Throwable $e) {
+            Log::error(sprintf('Speedtest batch "%s" failed for an unknown reason.', $batch->id));
+        })->name('Nettest Speedtest')->dispatch();
+
+        return $result;
+    }
+}

--- a/app/Enums/ResultService.php
+++ b/app/Enums/ResultService.php
@@ -7,12 +7,14 @@ use Filament\Support\Contracts\HasLabel;
 enum ResultService: string implements HasLabel
 {
     case Faker = 'faker';
+    case Nettest = 'nettest';
     case Ookla = 'ookla';
 
     public function getLabel(): ?string
     {
         return match ($this) {
             self::Faker => __('enums.service.faker'),
+            self::Nettest => __('enums.service.nettest'),
             self::Ookla => __('enums.service.ookla'),
         };
     }

--- a/app/Helpers/Nettest.php
+++ b/app/Helpers/Nettest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Helpers;
+
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+class Nettest
+{
+    /**
+     * Builds the nettest CLI command.
+     *
+     * Only options that are configured are passed, so nettest keeps applying its
+     * own defaults for everything else.
+     *
+     * @return array<int, string>
+     */
+    public static function getCommand(): array
+    {
+        return array_values(array_filter([
+            'nettest',
+            '-c',
+            (string) config('speedtest.nettest.server'),
+            config('speedtest.nettest.port') ? '-p' : null,
+            config('speedtest.nettest.port') ? (string) config('speedtest.nettest.port') : null,
+            config('speedtest.nettest.threads') ? '-t' : null,
+            config('speedtest.nettest.threads') ? (string) config('speedtest.nettest.threads') : null,
+            config('speedtest.nettest.tls') ? '-tls' : null,
+            config('speedtest.nettest.websocket') ? '-ws' : null,
+            '-json',
+        ]));
+    }
+
+    /**
+     * Gets the error message from a failed CLI process exception.
+     *
+     * Nettest reports its diagnostics on stderr as plain text, so the last
+     * non-empty line carries the reason the run failed.
+     */
+    public static function getErrorMessage(ProcessFailedException $exception): string
+    {
+        $output = trim($exception->getProcess()->getErrorOutput());
+
+        $lines = array_filter(
+            array_map('trim', explode(PHP_EOL, $output)),
+            fn (string $line): bool => $line !== ''
+        );
+
+        if (empty($lines)) {
+            return 'An unexpected error occurred while running the Nettest CLI.';
+        }
+
+        return implode(' | ', array_unique($lines));
+    }
+
+    /**
+     * Maps a nettest measurement onto the columns and the data of a result.
+     *
+     * Nettest reports speed in bits per second while the result columns hold
+     * bytes per second, so both speeds are converted and rounded because the
+     * columns are integers. Values that nettest did not measure stay absent
+     * instead of being stored as zero.
+     *
+     * @param  array<string, mixed>  $output
+     * @return array<string, mixed>
+     */
+    public static function mapResult(array $output): array
+    {
+        $downloadBits = data_get($output, 'download.speed_bps');
+        $uploadBits = data_get($output, 'upload.speed_bps');
+        $downloadBytes = data_get($output, 'download.bytes_transferred');
+        $uploadBytes = data_get($output, 'upload.bytes_transferred');
+
+        return [
+            'ping' => data_get($output, 'ping.latency_ms'),
+            'download' => $downloadBits !== null ? (int) round($downloadBits / 8) : null,
+            'upload' => $uploadBits !== null ? (int) round($uploadBits / 8) : null,
+            'download_bytes' => $downloadBytes,
+            'upload_bytes' => $uploadBytes,
+            'data' => [
+                'ping' => [
+                    'latency' => data_get($output, 'ping.latency_ms'),
+                    'jitter' => data_get($output, 'ping.jitter_ms'),
+                ],
+                'download' => [
+                    'bytes' => $downloadBytes,
+                ],
+                'upload' => [
+                    'bytes' => $uploadBytes,
+                ],
+                'packetLoss' => data_get($output, 'packet_loss_percent'),
+                'server' => [
+                    'name' => data_get($output, 'server.host'),
+                    'host' => data_get($output, 'server.host'),
+                    'port' => data_get($output, 'server.port'),
+                ],
+                'nettest' => $output,
+            ],
+        ];
+    }
+}

--- a/app/Jobs/Nettest/CompleteSpeedtestJob.php
+++ b/app/Jobs/Nettest/CompleteSpeedtestJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Nettest;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestCompleted;
+use App\Models\Result;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+
+class CompleteSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->result->update([
+            'status' => ResultStatus::Completed,
+        ]);
+
+        SpeedtestCompleted::dispatch($this->result);
+    }
+}

--- a/app/Jobs/Nettest/RunSpeedtestJob.php
+++ b/app/Jobs/Nettest/RunSpeedtestJob.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Jobs\Nettest;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestFailed;
+use App\Events\SpeedtestRunning;
+use App\Helpers\Nettest;
+use App\Models\Result;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+class RunSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * The number of seconds the job can run before timing out.
+     *
+     * Nettest runs a ping, a VoIP, a packet loss, a download and an upload
+     * phase, so it needs more time than a plain download and upload test.
+     *
+     * @var int
+     */
+    public $timeout = 180;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Get the middleware the job should pass through.
+     *
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->result->update([
+            'status' => ResultStatus::Running,
+        ]);
+
+        SpeedtestRunning::dispatch($this->result);
+
+        if (blank(config('speedtest.nettest.server'))) {
+            $this->markAsFailed('No Nettest server is configured, set NETTEST_SERVER to the address of your Nettest server.');
+
+            return;
+        }
+
+        $process = new Process(Nettest::getCommand());
+
+        try {
+            $process->mustRun();
+        } catch (ProcessFailedException $exception) {
+            $this->markAsFailed(Nettest::getErrorMessage($exception));
+
+            return;
+        }
+
+        $output = json_decode($process->getOutput(), true);
+
+        if (! is_array($output)) {
+            $this->markAsFailed('The Nettest CLI did not return a valid JSON result.');
+
+            return;
+        }
+
+        $this->result->update(Nettest::mapResult($output));
+    }
+
+    /**
+     * Marks the result as failed and stops the rest of the batch.
+     */
+    protected function markAsFailed(string $message): void
+    {
+        $this->result->update([
+            'data->type' => 'log',
+            'data->level' => 'error',
+            'data->message' => $message,
+            'status' => ResultStatus::Failed,
+        ]);
+
+        $this->batch()->cancel();
+
+        SpeedtestFailed::dispatch($this->result);
+    }
+}

--- a/app/Jobs/Nettest/StartSpeedtestJob.php
+++ b/app/Jobs/Nettest/StartSpeedtestJob.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Jobs\Nettest;
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestStarted;
+use App\Models\Result;
+use Illuminate\Bus\Batchable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Queue\Middleware\SkipIfBatchCancelled;
+
+class StartSpeedtestJob implements ShouldQueue
+{
+    use Batchable, Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Result $result,
+    ) {}
+
+    /**
+     * Get the middleware the job should pass through.
+     */
+    public function middleware(): array
+    {
+        return [
+            new SkipIfBatchCancelled,
+        ];
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        $this->result->update([
+            'status' => ResultStatus::Started,
+        ]);
+
+        SpeedtestStarted::dispatch($this->result);
+    }
+}

--- a/app/Livewire/Topbar/Actions.php
+++ b/app/Livewire/Topbar/Actions.php
@@ -2,8 +2,9 @@
 
 namespace App\Livewire\Topbar;
 
+use App\Actions\DispatchSpeedtest;
 use App\Actions\GetOoklaSpeedtestServers;
-use App\Actions\Ookla\RunSpeedtest;
+use App\Enums\ResultService;
 use App\Helpers\Ookla;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
@@ -37,8 +38,12 @@ class Actions extends Component implements HasActions, HasForms
 
     public function speedtestAction(): Action
     {
+        // Nettest takes its server from the configuration, so the Ookla server
+        // list is neither shown nor fetched when Nettest is the service.
+        $selectsServer = DispatchSpeedtest::service() !== ResultService::Nettest;
+
         return Action::make('speedtest')
-            ->schema([
+            ->schema($selectsServer ? [
                 Select::make('server_id')
                     ->label(__('results.select_server'))
                     ->helperText(__('results.select_server_helper'))
@@ -49,11 +54,11 @@ class Actions extends Component implements HasActions, HasForms
                         ]);
                     })
                     ->searchable(),
-            ])
+            ] : [])
             ->action(function (array $data) {
                 $serverId = $data['server_id'] ?? null;
 
-                RunSpeedtest::run(
+                DispatchSpeedtest::run(
                     serverId: $serverId,
                     dispatchedBy: Auth::id(),
                 );

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -21,6 +21,8 @@ return [
     /**
      * Speedtest settings.
      */
+    'service' => env('SPEEDTEST_SERVICE', 'ookla'),
+
     'schedule' => env('SPEEDTEST_SCHEDULE', false),
 
     'servers' => env('SPEEDTEST_SERVERS'),
@@ -28,6 +30,23 @@ return [
     'blocked_servers' => env('SPEEDTEST_BLOCKED_SERVERS'),
 
     'interface' => env('SPEEDTEST_INTERFACE'),
+
+    /**
+     * Nettest settings, used when the service is set to "nettest".
+     *
+     * Nettest has no public server list, so the server has to be set here.
+     */
+    'nettest' => [
+        'server' => env('NETTEST_SERVER'),
+
+        'port' => env('NETTEST_PORT'),
+
+        'threads' => env('NETTEST_THREADS'),
+
+        'tls' => env('NETTEST_TLS', false),
+
+        'websocket' => env('NETTEST_WEBSOCKET', false),
+    ],
 
     'preflight' => [
         'external_ip_url' => env('SPEEDTEST_CHECKINTERNET_URL') ?? env('SPEEDTEST_EXTERNAL_IP_URL', 'https://icanhazip.com'),

--- a/docker/8.4/Dockerfile
+++ b/docker/8.4/Dockerfile
@@ -7,6 +7,7 @@ ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=17
 ARG SPEEDTEST_VERSION=1.2.0
+ARG NETTEST_VERSION=2.1.0
 
 WORKDIR /var/www/html
 
@@ -57,6 +58,9 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -o /tmp/speedtest-cli.tgz -L \
          "https://install.speedtest.net/app/cli/ookla-speedtest-$SPEEDTEST_VERSION-linux-$PLATFORM.tgz" \
     && tar -xzf /tmp/speedtest-cli.tgz -C /usr/bin \
+    && curl -o /tmp/nettest.tar.gz -L \
+         "https://github.com/specure/nettest/releases/download/v$NETTEST_VERSION/nettest-linux-$PLATFORM.tar.gz" \
+    && tar -xzf /tmp/nettest.tar.gz -C /usr/bin \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/lang/en/enums.php
+++ b/lang/en/enums.php
@@ -16,6 +16,7 @@ return [
     // Service enum values
     'service' => [
         'faker' => 'Faker',
+        'nettest' => 'Nettest',
         'ookla' => 'Ookla',
     ],
 ];

--- a/tests/Feature/Actions/DispatchSpeedtestTest.php
+++ b/tests/Feature/Actions/DispatchSpeedtestTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Actions\DispatchSpeedtest;
+use App\Enums\ResultService;
+use App\Models\Result;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+
+describe('DispatchSpeedtest', function () {
+    it('runs a speedtest with ookla by default', function () {
+        Bus::fake();
+        Event::fake();
+
+        $result = DispatchSpeedtest::run();
+
+        expect($result)->toBeInstanceOf(Result::class);
+        expect($result->service)->toBe(ResultService::Ookla);
+    });
+
+    it('runs a speedtest with nettest when it is the configured service', function () {
+        Config::set('speedtest.service', 'nettest');
+        Bus::fake();
+        Event::fake();
+
+        $result = DispatchSpeedtest::run();
+
+        expect($result->service)->toBe(ResultService::Nettest);
+    });
+
+    it('falls back to ookla when the configured service is unknown', function () {
+        Config::set('speedtest.service', 'nope');
+
+        expect(DispatchSpeedtest::service())->toBe(ResultService::Ookla);
+    });
+});

--- a/tests/Feature/Actions/Nettest/RunSpeedtestTest.php
+++ b/tests/Feature/Actions/Nettest/RunSpeedtestTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Actions\Nettest\RunSpeedtest;
+use App\Enums\ResultService;
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestWaiting;
+use App\Models\Result;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Event;
+
+describe('Nettest RunSpeedtest', function () {
+    it('creates a waiting result for the nettest service', function () {
+        Bus::fake();
+        Event::fake();
+
+        $result = RunSpeedtest::run();
+
+        expect($result)->toBeInstanceOf(Result::class);
+        expect($result->service)->toBe(ResultService::Nettest);
+        expect($result->status)->toBe(ResultStatus::Waiting);
+        expect($result->scheduled)->toBeFalse();
+
+        Event::assertDispatched(SpeedtestWaiting::class);
+        Bus::assertBatched(fn ($batch) => $batch->name === 'Nettest Speedtest');
+    });
+
+    it('marks the result as scheduled and records who dispatched it', function () {
+        Bus::fake();
+        Event::fake();
+
+        $result = RunSpeedtest::run(scheduled: true, dispatchedBy: 1);
+
+        expect($result->scheduled)->toBeTrue();
+        expect($result->dispatched_by)->toBe(1);
+    });
+});

--- a/tests/Feature/Jobs/Nettest/RunSpeedtestJobTest.php
+++ b/tests/Feature/Jobs/Nettest/RunSpeedtestJobTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Enums\ResultService;
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestFailed;
+use App\Jobs\Nettest\RunSpeedtestJob;
+use App\Models\Result;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+
+describe('Nettest RunSpeedtestJob', function () {
+    it('fails the result with a helpful message when no server is configured', function () {
+        Config::set('speedtest.nettest.server', null);
+        Event::fake();
+
+        $result = Result::create([
+            'service' => ResultService::Nettest,
+            'status' => ResultStatus::Waiting,
+        ]);
+
+        [$job, $batch] = (new RunSpeedtestJob($result))->withFakeBatch();
+
+        $job->handle();
+
+        $result->refresh();
+
+        expect($result->status)->toBe(ResultStatus::Failed);
+        expect($result->data['message'])->toContain('NETTEST_SERVER');
+        expect($batch->cancelled())->toBeTrue();
+
+        Event::assertDispatched(SpeedtestFailed::class);
+    });
+});

--- a/tests/Unit/Helpers/NettestTest.php
+++ b/tests/Unit/Helpers/NettestTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Helpers\Nettest;
+use Illuminate\Support\Facades\Config;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+use Symfony\Component\Process\Process;
+
+/**
+ * Builds a failed process that reports the given diagnostics on stderr.
+ */
+function failedProcess(string $errorOutput): Process
+{
+    $process = Mockery::mock(Process::class);
+    $process->shouldReceive('isSuccessful')->andReturn(false);
+    $process->shouldReceive('getCommandLine')->andReturn('nettest -c 192.168.1.100 -json');
+    $process->shouldReceive('getExitCode')->andReturn(1);
+    $process->shouldReceive('getExitCodeText')->andReturn('General error');
+    $process->shouldReceive('getWorkingDirectory')->andReturn('/');
+    $process->shouldReceive('isOutputDisabled')->andReturn(false);
+    $process->shouldReceive('getOutput')->andReturn('');
+    $process->shouldReceive('getErrorOutput')->andReturn($errorOutput);
+
+    return $process;
+}
+
+describe('Nettest::getCommand', function () {
+    it('builds the command with the configured server', function () {
+        Config::set('speedtest.nettest', [
+            'server' => '192.168.1.100',
+            'port' => null,
+            'threads' => null,
+            'tls' => false,
+            'websocket' => false,
+        ]);
+
+        expect(Nettest::getCommand())->toBe([
+            'nettest',
+            '-c',
+            '192.168.1.100',
+            '-json',
+        ]);
+    });
+
+    it('passes the port, the threads and the protocol options when they are configured', function () {
+        Config::set('speedtest.nettest', [
+            'server' => 'nettest.example.com',
+            'port' => 5005,
+            'threads' => 4,
+            'tls' => true,
+            'websocket' => true,
+        ]);
+
+        expect(Nettest::getCommand())->toBe([
+            'nettest',
+            '-c',
+            'nettest.example.com',
+            '-p',
+            '5005',
+            '-t',
+            '4',
+            '-tls',
+            '-ws',
+            '-json',
+        ]);
+    });
+});
+
+describe('Nettest::mapResult', function () {
+    it('maps a complete measurement onto the result columns and data', function () {
+        $mapped = Nettest::mapResult([
+            'type' => 'measurement',
+            'ping' => ['latency_ms' => 12.34, 'jitter_ms' => 0.42],
+            'download' => ['speed_bps' => 800, 'bytes_transferred' => 1000],
+            'upload' => ['speed_bps' => 400, 'bytes_transferred' => 500],
+            'packet_loss_percent' => 0.5,
+            'server' => ['host' => '192.168.1.100', 'port' => 5005],
+        ]);
+
+        expect($mapped['ping'])->toBe(12.34);
+        expect($mapped['download'])->toEqual(100);
+        expect($mapped['upload'])->toEqual(50);
+        expect($mapped['download_bytes'])->toBe(1000);
+        expect($mapped['upload_bytes'])->toBe(500);
+        expect($mapped['data']['ping'])->toBe(['latency' => 12.34, 'jitter' => 0.42]);
+        expect($mapped['data']['packetLoss'])->toBe(0.5);
+        expect($mapped['data']['server'])->toBe([
+            'name' => '192.168.1.100',
+            'host' => '192.168.1.100',
+            'port' => 5005,
+        ]);
+    });
+
+    it('keeps the values that nettest did not measure absent', function () {
+        $mapped = Nettest::mapResult([
+            'type' => 'measurement',
+            'ping' => ['latency_ms' => 12.34],
+            'download' => ['speed_bps' => 800],
+            'upload' => ['speed_bps' => 400],
+            'server' => ['host' => '192.168.1.100', 'port' => 5005],
+        ]);
+
+        expect($mapped['download_bytes'])->toBeNull();
+        expect($mapped['upload_bytes'])->toBeNull();
+        expect($mapped['data']['ping']['jitter'])->toBeNull();
+        expect($mapped['data']['packetLoss'])->toBeNull();
+    });
+
+    it('rounds the speeds because the result columns hold whole bytes', function () {
+        $mapped = Nettest::mapResult([
+            'type' => 'measurement',
+            'download' => ['speed_bps' => 208744585758],
+            'upload' => ['speed_bps' => 176551252943],
+        ]);
+
+        expect($mapped['download'])->toBe(26093073220);
+        expect($mapped['upload'])->toBe(22068906618);
+    });
+
+    it('stores the measurement as reported by nettest', function () {
+        $output = [
+            'type' => 'measurement',
+            'client' => ['name' => 'nettest', 'version' => '2.1.0'],
+            'ping' => ['latency_ms' => 12.34],
+        ];
+
+        expect(Nettest::mapResult($output)['data']['nettest'])->toBe($output);
+    });
+});
+
+describe('Nettest::getErrorMessage', function () {
+    it('returns the diagnostics that nettest reported on stderr', function () {
+        $process = failedProcess("Could not connect to server\nCould not connect to server\n");
+
+        $message = Nettest::getErrorMessage(new ProcessFailedException($process));
+
+        expect($message)->toBe('Could not connect to server');
+    });
+
+    it('falls back to a generic message when nettest reported nothing', function () {
+        $process = failedProcess('');
+
+        $message = Nettest::getErrorMessage(new ProcessFailedException($process));
+
+        expect($message)->toBe('An unexpected error occurred while running the Nettest CLI.');
+    });
+});


### PR DESCRIPTION
Refs discussion #976, closes #1722, related to #64.

## What this adds

Nettest is an open source speedtest client and server (https://github.com/specure/nettest). With this change a user can run the tests against their own nettest server instead of the Ookla network. Ookla stays the default, so nothing changes for current users.

Two variables turn it on:

```
SPEEDTEST_SERVICE=nettest
NETTEST_SERVER=192.168.1.100
```

`NETTEST_PORT`, `NETTEST_THREADS`, `NETTEST_TLS` and `NETTEST_WEBSOCKET` are optional. When they are unset, the flags are left out and nettest applies its own defaults, so the two projects cannot drift apart.

## How it fits the current code

Everything mirrors the Ookla pieces, so there is nothing new to learn and no new dependency:

- `ResultService::Nettest` in the service enum, with its label in `lang/en/enums.php`
- `app/Actions/Nettest/RunSpeedtest.php` creates the result and dispatches the batch
- `app/Jobs/Nettest/*` runs the CLI, the same way as `app/Jobs/Ookla/*`
- `app/Helpers/Nettest.php` builds the command and maps the output
- `app/Actions/DispatchSpeedtest.php` reads the configured service and delegates, so the scheduler and the topbar button stay as they are
- the CLI is installed in `docker/8.4/Dockerfile`, next to the Ookla one and pinned the same way

There is no migration. The `service` column is already a string.

## About the data

Nettest 2.1.0 gained a `-json` option for this integration (https://github.com/specure/nettest/pull/67). It reports its own units, so the helper converts them: speed comes in bits per second and the columns hold bytes per second. The whole document is kept under `data->nettest`, so nothing is lost.

Nettest measures jitter on an idle line, so that value is stored as the ping jitter only. It does not measure jitter under load, so the download and upload jitter stay null. The ISP and the result URL do not exist for a self hosted server, so they stay null as well. The dashboard, the tables and the notifications handle these nulls today.

## What is not included

The skip IP list and the threshold checks live in `App\Jobs\Ookla`, so they apply to Ookla runs only. Both jobs are generic and moving them is a small follow up, which I am happy to send after this one. I kept this pull request focused.

## Tests

14 new tests cover the command, the mapping, the failure path and the dispatcher. They do not need the CLI, so CI stays as it is. `pint` passes on all files.

I also ran it against a real nettest server: the result is completed, and the ping, the speeds, the jitter and the packet loss all match what the client reported.