### PR TITLE
fix: clamp negative values from the Ookla CLI

### DIFF
--- a/app/Helpers/Ookla.php
+++ b/app/Helpers/Ookla.php
@@ -2,6 +2,7 @@
 
 namespace App\Helpers;
 
+use Illuminate\Support\Arr;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 
 class Ookla
@@ -28,6 +29,34 @@ class Ookla
 
         // Remove duplicates and concatenate
         return implode(' | ', array_unique($errorMessages));
+    }
+
+    /**
+     * Clamps negative metric values the CLI sometimes returns to zero.
+     */
+    public static function clampNegativeValues(?array $output): ?array
+    {
+        if ($output === null) {
+            return null;
+        }
+
+        $paths = [
+            'ping.latency',
+            'download.bandwidth',
+            'download.bytes',
+            'upload.bandwidth',
+            'upload.bytes',
+        ];
+
+        foreach ($paths as $path) {
+            $value = Arr::get($output, $path);
+
+            if (is_numeric($value) && $value < 0) {
+                Arr::set($output, $path, 0);
+            }
+        }
+
+        return $output;
     }
 
     public static function getConfigServers(): ?array

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -87,6 +87,8 @@ class RunSpeedtestJob implements ShouldQueue
 
         $output = json_decode($process->getOutput(), true);
 
+        $output = Ookla::clampNegativeValues($output);
+
         $this->result->update([
             'ping' => Arr::get($output, 'ping.latency'),
             'download' => Arr::get($output, 'download.bandwidth'),

--- a/tests/Unit/OoklaTest.php
+++ b/tests/Unit/OoklaTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Helpers\Ookla;
+
+test('negative metric values are clamped to zero', function () {
+    $output = [
+        'ping' => ['latency' => -3.2, 'jitter' => 1.1],
+        'download' => ['bandwidth' => -12345, 'bytes' => -67890],
+        'upload' => ['bandwidth' => 23456, 'bytes' => 78901],
+    ];
+
+    $clamped = Ookla::clampNegativeValues($output);
+
+    expect($clamped['ping']['latency'])->toBe(0)
+        ->and($clamped['download']['bandwidth'])->toBe(0)
+        ->and($clamped['download']['bytes'])->toBe(0)
+        ->and($clamped['upload']['bandwidth'])->toBe(23456)
+        ->and($clamped['upload']['bytes'])->toBe(78901)
+        ->and($clamped['ping']['jitter'])->toBe(1.1);
+});
+
+test('null and missing values pass through untouched', function () {
+    $output = ['download' => ['bandwidth' => null]];
+
+    $clamped = Ookla::clampNegativeValues($output);
+
+    expect($clamped['download']['bandwidth'])->toBeNull()
+        ->and($clamped)->not->toHaveKey('upload')
+        ->and(Ookla::clampNegativeValues(null))->toBeNull();
+});


### PR DESCRIPTION
## 📃 Description

As offered in #2864. The decoded CLI output runs through a small clamp before anything is stored, so the mapped columns and the same fields inside `data` stay consistent — ping latency, bandwidth and bytes in both directions. Nulls and missing fields pass through untouched so a failed metric doesn't turn into a fake zero, and everything else in the json is left as the CLI reported it. Only new results are guarded, existing rows aren't rewritten.

Closes #2864

## 🪵 Changelog

### 🔧 Fixed

- negative values from the Ookla CLI are clamped to zero before being stored