### PR TITLE
Add CHART_USE_AVERAGE_LATENCY option to plot average instead of high/low on latency charts

### DIFF
--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -48,42 +48,48 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ->orderBy('created_at')
             ->get();
 
-        return [
-            'datasets' => [
-                [
-                    'label' => __('general.average_ms'),
-                    'data' => $results->map(fn ($item) => $item->download_latency_iqm),
-                    'borderColor' => 'rgba(16, 185, 129)',
-                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
-                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
-                [
-                    'label' => __('general.high_ms'),
-                    'data' => $results->map(fn ($item) => $item->download_latency_high),
-                    'borderColor' => 'rgba(14, 165, 233)',
-                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
-                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
-                [
-                    'label' => __('general.low_ms'),
-                    'data' => $results->map(fn ($item) => $item->download_latency_low),
-                    'borderColor' => 'rgba(139, 92, 246)',
-                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
-                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
+        $datasets = [
+            [
+                'label' => __('general.average_ms'),
+                'data' => $results->map(fn ($item) => $item->download_latency_iqm),
+                'borderColor' => 'rgba(16, 185, 129)',
+                'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                'pointBackgroundColor' => 'rgba(16, 185, 129)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
             ],
+        ];
+
+        if (! config('speedtest.chart_use_average_latency')) {
+            $datasets[] = [
+                'label' => __('general.high_ms'),
+                'data' => $results->map(fn ($item) => $item->download_latency_high),
+                'borderColor' => 'rgba(14, 165, 233)',
+                'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                'pointBackgroundColor' => 'rgba(14, 165, 233)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
+            ];
+
+            $datasets[] = [
+                'label' => __('general.low_ms'),
+                'data' => $results->map(fn ($item) => $item->download_latency_low),
+                'borderColor' => 'rgba(139, 92, 246)',
+                'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                'pointBackgroundColor' => 'rgba(139, 92, 246)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
+            ];
+        }
+
+        return [
+            'datasets' => $datasets,
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -48,42 +48,48 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ->orderBy('created_at')
             ->get();
 
-        return [
-            'datasets' => [
-                [
-                    'label' => __('general.average_ms'),
-                    'data' => $results->map(fn ($item) => $item->upload_latency_iqm),
-                    'borderColor' => 'rgba(16, 185, 129)',
-                    'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
-                    'pointBackgroundColor' => 'rgba(16, 185, 129)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
-                [
-                    'label' => __('general.high_ms'),
-                    'data' => $results->map(fn ($item) => $item->upload_latency_high),
-                    'borderColor' => 'rgba(14, 165, 233)',
-                    'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
-                    'pointBackgroundColor' => 'rgba(14, 165, 233)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
-                [
-                    'label' => __('general.low_ms'),
-                    'data' => $results->map(fn ($item) => $item->upload_latency_low),
-                    'borderColor' => 'rgba(139, 92, 246)',
-                    'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
-                    'pointBackgroundColor' => 'rgba(139, 92, 246)',
-                    'fill' => true,
-                    'cubicInterpolationMode' => 'monotone',
-                    'tension' => 0.4,
-                    'pointRadius' => count($results) <= 24 ? 3 : 0,
-                ],
+        $datasets = [
+            [
+                'label' => __('general.average_ms'),
+                'data' => $results->map(fn ($item) => $item->upload_latency_iqm),
+                'borderColor' => 'rgba(16, 185, 129)',
+                'backgroundColor' => 'rgba(16, 185, 129, 0.1)',
+                'pointBackgroundColor' => 'rgba(16, 185, 129)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
             ],
+        ];
+
+        if (! config('speedtest.chart_use_average_latency')) {
+            $datasets[] = [
+                'label' => __('general.high_ms'),
+                'data' => $results->map(fn ($item) => $item->upload_latency_high),
+                'borderColor' => 'rgba(14, 165, 233)',
+                'backgroundColor' => 'rgba(14, 165, 233, 0.1)',
+                'pointBackgroundColor' => 'rgba(14, 165, 233)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
+            ];
+
+            $datasets[] = [
+                'label' => __('general.low_ms'),
+                'data' => $results->map(fn ($item) => $item->upload_latency_low),
+                'borderColor' => 'rgba(139, 92, 246)',
+                'backgroundColor' => 'rgba(139, 92, 246, 0.1)',
+                'pointBackgroundColor' => 'rgba(139, 92, 246)',
+                'fill' => true,
+                'cubicInterpolationMode' => 'monotone',
+                'tension' => 0.4,
+                'pointRadius' => count($results) <= 24 ? 3 : 0,
+            ];
+        }
+
+        return [
+            'datasets' => $datasets,
             'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
         ];
     }

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -18,6 +18,8 @@ return [
 
     'default_chart_range' => strtolower(env('DEFAULT_CHART_RANGE', '24h')),
 
+    'chart_use_average_latency' => (bool) env('CHART_USE_AVERAGE_LATENCY', false),
+
     /**
      * Speedtest settings.
      */


### PR DESCRIPTION
Download/upload latency charts currently plot Average (IQM), High, and Low as three separate lines. The High line reflects a single outlier sample within one test and can visually dominate the chart's scale, misrepresenting typical performance — e.g. a 1714ms high sample vs. a 244ms IQM average from the same test result.

This adds an opt-in `CHART_USE_AVERAGE_LATENCY` config/env option. When set to `true`, the download and upload latency charts plot only the Average (IQM) line. Default is `false`, preserving existing behavior.

Note: I wasn't able to spin up the app locally to visually verify (no Docker in this environment), so this hasn't been manually tested in a running instance yet.