### PR TITLE
Fix outbound URL protocol validation

### DIFF
--- a/app/Filament/Pages/Settings/DataIntegration.php
+++ b/app/Filament/Pages/Settings/DataIntegration.php
@@ -71,6 +71,8 @@ class DataIntegration extends SettingsPage
                                         TextInput::make('influxdb_v2_url')
                                             ->label(__('settings/data_integration.influxdb_v2_url'))
                                             ->placeholder(__('settings/data_integration.influxdb_v2_url_placeholder'))
+                                            ->url()
+                                            ->rule('url:http,https')
                                             ->maxLength(255)
                                             ->required(fn (Get $get) => $get('influxdb_v2_enabled') === true)
                                             ->columnSpan(['md' => 1]),

--- a/app/Filament/Pages/Settings/Notification.php
+++ b/app/Filament/Pages/Settings/Notification.php
@@ -174,6 +174,7 @@ class Notification extends SettingsPage
                                                     ->maxLength(2000)
                                                     ->required()
                                                     ->url()
+                                                    ->rule('url:http,https')
                                                     ->rule(new ContainsString('/notify'))
                                                     ->columnSpanFull(),
                                                 Checkbox::make('apprise_verify_ssl')

--- a/app/Filament/Resources/Webhooks/Schemas/WebhookForm.php
+++ b/app/Filament/Resources/Webhooks/Schemas/WebhookForm.php
@@ -16,6 +16,7 @@ class WebhookForm
                 ->label(__('webhooks.url'))
                 ->placeholder('https://webhook.site/longstringofcharacters')
                 ->url()
+                ->rule('url:http,https')
                 ->required()
                 ->maxLength(2000),
 

--- a/tests/Feature/Filament/Settings/UrlSchemeValidationTest.php
+++ b/tests/Feature/Filament/Settings/UrlSchemeValidationTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use App\Enums\UserRole;
+use App\Filament\Pages\Settings\DataIntegration;
+use App\Filament\Pages\Settings\Notification;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function () {
+    actingAs(User::factory()->create(['role' => UserRole::Admin]));
+});
+
+it('accepts HTTP and HTTPS InfluxDB URLs', function (string $url) {
+    Livewire::test(DataIntegration::class)
+        ->fillForm([
+            'influxdb_v2_enabled' => true,
+            'influxdb_v2_url' => $url,
+            'influxdb_v2_org' => 'speedtest-tracker',
+            'influxdb_v2_bucket' => 'results',
+            'influxdb_v2_token' => 'token',
+            'influxdb_v2_verify_ssl' => true,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+})->with([
+    'HTTP container hostname' => 'http://influxdb:8086',
+    'HTTPS loopback address' => 'https://127.0.0.1:8086',
+]);
+
+it('rejects non-HTTP InfluxDB URL protocols', function (string $url) {
+    Livewire::test(DataIntegration::class)
+        ->fillForm([
+            'influxdb_v2_enabled' => true,
+            'influxdb_v2_url' => $url,
+            'influxdb_v2_org' => 'speedtest-tracker',
+            'influxdb_v2_bucket' => 'results',
+            'influxdb_v2_token' => 'token',
+            'influxdb_v2_verify_ssl' => true,
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['influxdb_v2_url' => 'url']);
+})->with([
+    'FTP' => 'ftp://influxdb:8086',
+    'file' => 'file:///tmp/influxdb.sock',
+    'Gopher' => 'gopher://influxdb:70',
+]);
+
+it('accepts HTTP and HTTPS Apprise server URLs', function (string $url) {
+    Livewire::test(Notification::class)
+        ->fillForm([
+            'apprise_enabled' => true,
+            'apprise_server_url' => $url,
+            'apprise_verify_ssl' => true,
+            'apprise_on_speedtest_run' => true,
+            'apprise_on_threshold_failure' => false,
+            'apprise_channel_urls' => [
+                ['channel_url' => 'discord://webhook-id/webhook-token'],
+            ],
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+})->with([
+    'HTTP container hostname' => 'http://apprise:8000/notify',
+    'HTTPS private address' => 'https://192.168.1.10:8000/notify',
+]);
+
+it('rejects non-HTTP Apprise server URL protocols', function (string $url) {
+    Livewire::test(Notification::class)
+        ->fillForm([
+            'apprise_enabled' => true,
+            'apprise_server_url' => $url,
+            'apprise_verify_ssl' => true,
+            'apprise_on_speedtest_run' => true,
+            'apprise_on_threshold_failure' => false,
+            'apprise_channel_urls' => [
+                ['channel_url' => 'discord://webhook-id/webhook-token'],
+            ],
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['apprise_server_url' => 'url']);
+})->with([
+    'FTP' => 'ftp://apprise:8000/notify',
+    'file' => 'file:///tmp/notify',
+    'Gopher' => 'gopher://apprise:70/notify',
+]);

--- a/tests/Feature/Webhooks/WebhookResourceTest.php
+++ b/tests/Feature/Webhooks/WebhookResourceTest.php
@@ -45,6 +45,39 @@ it('creates a webhook through the form', function () {
     ]);
 });
 
+it('accepts HTTP and HTTPS webhook URLs', function (string $url) {
+    actingAs($this->admin);
+
+    Livewire::test(ListWebhooks::class)
+        ->callAction('create', [
+            'url' => $url,
+            'events' => [WebhookEvent::Completed->value],
+            'enabled' => true,
+        ])
+        ->assertHasNoActionErrors();
+
+    assertDatabaseHas('webhooks', ['url' => $url]);
+})->with([
+    'HTTP container hostname' => 'http://webhook-receiver:8080/hook',
+    'HTTPS loopback address' => 'https://127.0.0.1:8443/hook',
+]);
+
+it('rejects non-HTTP webhook URL protocols', function (string $url) {
+    actingAs($this->admin);
+
+    Livewire::test(ListWebhooks::class)
+        ->callAction('create', [
+            'url' => $url,
+            'events' => [WebhookEvent::Completed->value],
+            'enabled' => true,
+        ])
+        ->assertHasActionErrors(['url' => 'url']);
+})->with([
+    'FTP' => 'ftp://webhook-receiver/hook',
+    'file' => 'file:///tmp/webhook',
+    'Gopher' => 'gopher://webhook-receiver/hook',
+]);
+
 it('validates the webhook form', function () {
     actingAs($this->admin);
 


### PR DESCRIPTION
## Summary
- restrict directly contacted integration and webhook URLs to HTTP or HTTPS
- preserve local, private, and container-hosted destinations
- add coverage for supported and rejected URL protocols

## Testing
- `vendor/bin/sail artisan test --compact tests/Feature/Filament/Settings/UrlSchemeValidationTest.php`
- `vendor/bin/sail artisan test --compact tests/Feature/Webhooks/WebhookResourceTest.php`
- `vendor/bin/sail bin pint --dirty --format agent`