### PR TITLE
Feature/retry on failure

### DIFF
--- a/app/Actions/Ookla/RetrySpeedtest.php
+++ b/app/Actions/Ookla/RetrySpeedtest.php
@@ -14,7 +14,7 @@ class RetrySpeedtest
      */
     public function handle(Result $result, int $attempt): void
     {
-        $retryTimes = config('speedtest.retry_times');
+        $retryTimes = (int) config('speedtest.retry_times');
 
         // Retrying is disabled entirely.
         if ($retryTimes === 0) {

--- a/app/Actions/Ookla/RetrySpeedtest.php
+++ b/app/Actions/Ookla/RetrySpeedtest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions\Ookla;
+
+use App\Models\Result;
+use Lorisleiva\Actions\Concerns\AsAction;
+
+class RetrySpeedtest
+{
+    use AsAction;
+
+    /**
+     * Dispatch the next attempt if retries are enabled and attempts remain.
+     */
+    public function handle(Result $result, int $attempt): void
+    {
+        $retryTimes = config('speedtest.retry_times');
+
+        // Retrying is disabled entirely.
+        if ($retryTimes === 0) {
+            return;
+        }
+
+        // No attempts remain.
+        if ($attempt > $retryTimes) {
+            return;
+        }
+
+        RunSpeedtest::run(
+            scheduled: $result->scheduled,
+            serverId: $result->server_id,
+            dispatchedBy: $result->dispatched_by,
+            attempt: $attempt + 1,
+        );
+    }
+}

--- a/app/Actions/Ookla/RunSpeedtest.php
+++ b/app/Actions/Ookla/RunSpeedtest.php
@@ -23,6 +23,9 @@ class RunSpeedtest
 {
     use AsAction;
 
+    /**
+     * Handle the action.
+     */
     public function handle(bool $scheduled = false, ?int $serverId = null, ?int $dispatchedBy = null, int $attempt = 1): mixed
     {
         $result = Result::create([

--- a/app/Actions/Ookla/RunSpeedtest.php
+++ b/app/Actions/Ookla/RunSpeedtest.php
@@ -23,7 +23,7 @@ class RunSpeedtest
 {
     use AsAction;
 
-    public function handle(bool $scheduled = false, ?int $serverId = null, ?int $dispatchedBy = null): mixed
+    public function handle(bool $scheduled = false, ?int $serverId = null, ?int $dispatchedBy = null, int $attempt = 1): mixed
     {
         $result = Result::create([
             'data->server->id' => $serverId,
@@ -38,11 +38,11 @@ class RunSpeedtest
         Bus::batch([
             [
                 new StartSpeedtestJob($result),
-                new CheckForInternetConnectionJob($result),
-                new SkipSpeedtestJob($result),
+                new CheckForInternetConnectionJob($result, $attempt),
+                new SkipSpeedtestJob($result, $attempt),
                 new SelectSpeedtestServerJob($result),
-                new RunSpeedtestJob($result),
-                new BenchmarkSpeedtestJob($result),
+                new RunSpeedtestJob($result, $attempt),
+                new BenchmarkSpeedtestJob($result, $attempt),
                 new CompleteSpeedtestJob($result),
             ],
         ])->catch(function (Batch $batch, ?Throwable $e) {

--- a/app/Events/SpeedtestBenchmarkUnhealthy.php
+++ b/app/Events/SpeedtestBenchmarkUnhealthy.php
@@ -15,5 +15,6 @@ class SpeedtestBenchmarkUnhealthy
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 }

--- a/app/Events/SpeedtestFailed.php
+++ b/app/Events/SpeedtestFailed.php
@@ -15,5 +15,6 @@ class SpeedtestFailed
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 }

--- a/app/Jobs/CheckForInternetConnectionJob.php
+++ b/app/Jobs/CheckForInternetConnectionJob.php
@@ -24,6 +24,7 @@ class CheckForInternetConnectionJob implements ShouldQueue
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 
     /**
@@ -71,7 +72,7 @@ class CheckForInternetConnectionJob implements ShouldQueue
             'status' => ResultStatus::Failed,
         ]);
 
-        SpeedtestFailed::dispatch($this->result);
+        SpeedtestFailed::dispatch($this->result, $this->attempt);
 
         $this->batch()->cancel();
     }

--- a/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
+++ b/app/Jobs/Ookla/BenchmarkSpeedtestJob.php
@@ -27,6 +27,7 @@ class BenchmarkSpeedtestJob implements ShouldQueue
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 
     /**
@@ -72,7 +73,7 @@ class BenchmarkSpeedtestJob implements ShouldQueue
 
         $this->healthy
             ? SpeedtestBenchmarkHealthy::dispatch($this->result)
-            : SpeedtestBenchmarkUnhealthy::dispatch($this->result);
+            : SpeedtestBenchmarkUnhealthy::dispatch($this->result, $this->attempt);
     }
 
     private function benchmark(Result $result, ThresholdSettings $settings): array

--- a/app/Jobs/Ookla/RunSpeedtestJob.php
+++ b/app/Jobs/Ookla/RunSpeedtestJob.php
@@ -31,6 +31,7 @@ class RunSpeedtestJob implements ShouldQueue
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 
     /**
@@ -80,7 +81,7 @@ class RunSpeedtestJob implements ShouldQueue
 
             $this->batch()->cancel();
 
-            SpeedtestFailed::dispatch($this->result);
+            SpeedtestFailed::dispatch($this->result, $this->attempt);
 
             return;
         }

--- a/app/Jobs/Ookla/SkipSpeedtestJob.php
+++ b/app/Jobs/Ookla/SkipSpeedtestJob.php
@@ -22,6 +22,7 @@ class SkipSpeedtestJob implements ShouldQueue
      */
     public function __construct(
         public Result $result,
+        public int $attempt = 1,
     ) {}
 
     /**
@@ -56,7 +57,7 @@ class SkipSpeedtestJob implements ShouldQueue
                 'status' => ResultStatus::Failed,
             ]);
 
-            SpeedtestFailed::dispatch($this->result);
+            SpeedtestFailed::dispatch($this->result, $this->attempt);
 
             $this->batch()->cancel();
 

--- a/app/Listeners/DispatchWebhooks.php
+++ b/app/Listeners/DispatchWebhooks.php
@@ -4,6 +4,8 @@ namespace App\Listeners;
 
 use App\Actions\Webhooks\BuildWebhookPayload;
 use App\Enums\WebhookEvent;
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use App\Events\SpeedtestFailed;
 use App\Models\Webhook;
 use Illuminate\Events\Dispatcher;
 use Spatie\WebhookServer\WebhookCall;
@@ -15,6 +17,11 @@ class DispatchWebhooks
      */
     public function handle(object $event): void
     {
+        // Don't dispatch webhooks for attempts that will still be retried.
+        if (($event instanceof SpeedtestFailed || $event instanceof SpeedtestBenchmarkUnhealthy) && $event->attempt <= (int) config('speedtest.retry_times')) {
+            return;
+        }
+
         $webhookEvent = WebhookEvent::fromEventClass(get_class($event));
 
         if ($webhookEvent === null) {

--- a/app/Listeners/ProcessFailedSpeedtest.php
+++ b/app/Listeners/ProcessFailedSpeedtest.php
@@ -19,6 +19,11 @@ class ProcessFailedSpeedtest
             return;
         }
 
+        // Don't notify for attempts that will still be retried.
+        if ($event->attempt <= (int) config('speedtest.retry_times')) {
+            return;
+        }
+
         // $this->notifyAppriseChannels($result);
     }
 

--- a/app/Listeners/ProcessUnhealthySpeedtest.php
+++ b/app/Listeners/ProcessUnhealthySpeedtest.php
@@ -37,6 +37,11 @@ class ProcessUnhealthySpeedtest
             return;
         }
 
+        // Don't notify for attempts that will still be retried.
+        if ($event->attempt <= (int) config('speedtest.retry_times')) {
+            return;
+        }
+
         $this->notifyAppriseChannels($result);
         $this->notifyDatabaseChannels($result);
         $this->notifyMailChannels($result);

--- a/app/Listeners/RetryFailedSpeedtest.php
+++ b/app/Listeners/RetryFailedSpeedtest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Actions\Ookla\RetrySpeedtest;
+use App\Events\SpeedtestFailed;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class RetryFailedSpeedtest implements ShouldQueue
+{
+    /**
+     * The number of seconds to delay the job.
+     *
+     * @var int
+     */
+    public $delay;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        $this->delay = config('speedtest.retry_delay');
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestFailed $event): void
+    {
+        RetrySpeedtest::run($event->result, $event->attempt);
+    }
+}

--- a/app/Listeners/RetryFailedSpeedtest.php
+++ b/app/Listeners/RetryFailedSpeedtest.php
@@ -9,18 +9,19 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 class RetryFailedSpeedtest implements ShouldQueue
 {
     /**
-     * The number of seconds to delay the job.
-     *
-     * @var int
+     * Determine the number of seconds before the retry should be dispatched.
      */
-    public $delay;
+    public function withDelay(SpeedtestFailed $event): int
+    {
+        return max(0, (int) config('speedtest.retry_delay'));
+    }
 
     /**
-     * Create the event listener.
+     * Determine whether the listener should be queued.
      */
-    public function __construct()
+    public function shouldQueue(SpeedtestFailed $event): bool
     {
-        $this->delay = config('speedtest.retry_delay');
+        return (int) config('speedtest.retry_times') > 0;
     }
 
     /**

--- a/app/Listeners/RetryUnhealthySpeedtest.php
+++ b/app/Listeners/RetryUnhealthySpeedtest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Actions\Ookla\RetrySpeedtest;
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class RetryUnhealthySpeedtest implements ShouldQueue
+{
+    /**
+     * The number of seconds to delay the job.
+     *
+     * @var int
+     */
+    public $delay;
+
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        $this->delay = config('speedtest.retry_delay');
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(SpeedtestBenchmarkUnhealthy $event): void
+    {
+        RetrySpeedtest::run($event->result, $event->attempt);
+    }
+}

--- a/app/Listeners/RetryUnhealthySpeedtest.php
+++ b/app/Listeners/RetryUnhealthySpeedtest.php
@@ -9,18 +9,19 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 class RetryUnhealthySpeedtest implements ShouldQueue
 {
     /**
-     * The number of seconds to delay the job.
-     *
-     * @var int
+     * Determine the number of seconds before the retry should be dispatched.
      */
-    public $delay;
+    public function withDelay(SpeedtestBenchmarkUnhealthy $event): int
+    {
+        return max(0, (int) config('speedtest.retry_delay'));
+    }
 
     /**
-     * Create the event listener.
+     * Determine whether the listener should be queued.
      */
-    public function __construct()
+    public function shouldQueue(SpeedtestBenchmarkUnhealthy $event): bool
     {
-        $this->delay = config('speedtest.retry_delay');
+        return (int) config('speedtest.retry_times') > 0;
     }
 
     /**

--- a/app/Listeners/UserNotificationSubscriber.php
+++ b/app/Listeners/UserNotificationSubscriber.php
@@ -51,6 +51,11 @@ class UserNotificationSubscriber
             return;
         }
 
+        // Don't notify for attempts that will still be retried.
+        if ($event->attempt <= (int) config('speedtest.retry_times')) {
+            return;
+        }
+
         $result->loadMissing('dispatchedBy');
 
         Notification::make()
@@ -72,6 +77,11 @@ class UserNotificationSubscriber
         $result = $event->result;
 
         if (empty($result->dispatched_by)) {
+            return;
+        }
+
+        // Don't notify for attempts that will still be retried.
+        if ($event->attempt <= (int) config('speedtest.retry_times')) {
             return;
         }
 

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -31,6 +31,10 @@ return [
 
     'interface' => env('SPEEDTEST_INTERFACE'),
 
+    'retry_times' => (int) env('SPEEDTEST_RETRY_TIMES', 0),
+
+    'retry_delay' => (int) env('SPEEDTEST_RETRY_DELAY', 5),
+
     'preflight' => [
         'external_ip_url' => env('SPEEDTEST_CHECKINTERNET_URL') ?? env('SPEEDTEST_EXTERNAL_IP_URL', 'https://icanhazip.com'),
         'internet_check_hostname' => env('SPEEDTEST_CHECKINTERNET_URL') ?? env('SPEEDTEST_INTERNET_CHECK_HOSTNAME', 'icanhazip.com'),

--- a/tests/Feature/Actions/RetrySpeedtestTest.php
+++ b/tests/Feature/Actions/RetrySpeedtestTest.php
@@ -43,4 +43,16 @@ describe('RetrySpeedtest', function () {
 
         Bus::assertNothingBatched();
     });
+
+    it('still dispatches when attempt exactly equals retry_times', function () {
+        Config::set('speedtest.retry_times', 2);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+
+        RetrySpeedtest::run($result, 2);
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            return $batch->jobs->flatten()->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 3;
+        });
+    });
 });

--- a/tests/Feature/Actions/RetrySpeedtestTest.php
+++ b/tests/Feature/Actions/RetrySpeedtestTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use App\Actions\Ookla\RetrySpeedtest;
+use App\Jobs\Ookla\RunSpeedtestJob;
+use App\Models\Result;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Bus::fake();
+});
+
+describe('RetrySpeedtest', function () {
+    it('does not dispatch another attempt when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+
+        RetrySpeedtest::run($result, 1);
+
+        Bus::assertNothingBatched();
+    });
+
+    it('dispatches the next attempt when attempts remain', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+
+        RetrySpeedtest::run($result, 1);
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            return $batch->jobs->flatten()->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 2;
+        });
+    });
+
+    it('does not dispatch once attempts are exhausted', function () {
+        Config::set('speedtest.retry_times', 2);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+
+        RetrySpeedtest::run($result, 3);
+
+        Bus::assertNothingBatched();
+    });
+});

--- a/tests/Feature/Actions/RunSpeedtestTest.php
+++ b/tests/Feature/Actions/RunSpeedtestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Actions\Ookla\RunSpeedtest;
+use App\Jobs\CheckForInternetConnectionJob;
+use App\Jobs\Ookla\BenchmarkSpeedtestJob;
+use App\Jobs\Ookla\RunSpeedtestJob;
+use App\Jobs\Ookla\SkipSpeedtestJob;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+
+beforeEach(function () {
+    Bus::fake();
+});
+
+describe('RunSpeedtest', function () {
+    it('defaults new runs to attempt 1', function () {
+        RunSpeedtest::run();
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            $jobs = $batch->jobs->flatten();
+
+            return $jobs->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 1
+                && $jobs->first(fn ($job) => $job instanceof BenchmarkSpeedtestJob)?->attempt === 1
+                && $jobs->first(fn ($job) => $job instanceof SkipSpeedtestJob)?->attempt === 1
+                && $jobs->first(fn ($job) => $job instanceof CheckForInternetConnectionJob)?->attempt === 1;
+        });
+    });
+
+    it('threads a specific attempt number into every job that can report failure', function () {
+        RunSpeedtest::run(attempt: 3);
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            $jobs = $batch->jobs->flatten();
+
+            return $jobs->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 3
+                && $jobs->first(fn ($job) => $job instanceof BenchmarkSpeedtestJob)?->attempt === 3
+                && $jobs->first(fn ($job) => $job instanceof SkipSpeedtestJob)?->attempt === 3
+                && $jobs->first(fn ($job) => $job instanceof CheckForInternetConnectionJob)?->attempt === 3;
+        });
+    });
+});

--- a/tests/Feature/BenchmarkSpeedtestJobTest.php
+++ b/tests/Feature/BenchmarkSpeedtestJobTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use App\Jobs\Ookla\BenchmarkSpeedtestJob;
+use App\Models\Result;
+use App\Settings\ThresholdSettings;
+use Illuminate\Support\Facades\Event;
+
+beforeEach(function () {
+    Event::fake();
+});
+
+describe('BenchmarkSpeedtestJob', function () {
+    test('defaults to attempt 1 when not specified', function () {
+        $result = Result::factory()->create();
+
+        $job = new BenchmarkSpeedtestJob($result);
+
+        expect($job->attempt)->toBe(1);
+    });
+
+    test('accepts and stores a specific attempt number', function () {
+        $result = Result::factory()->create();
+
+        $job = new BenchmarkSpeedtestJob($result, 2);
+
+        expect($job->attempt)->toBe(2);
+    });
+
+    test('dispatches SpeedtestBenchmarkUnhealthy with the current attempt number', function () {
+        $settings = app(ThresholdSettings::class);
+        $settings->absolute_enabled = true;
+        $settings->absolute_download = 100;
+        $settings->save();
+
+        $result = Result::factory()->create([
+            'download' => 1,
+        ]);
+
+        $job = new BenchmarkSpeedtestJob($result, 3);
+        $job->handle();
+
+        Event::assertDispatched(SpeedtestBenchmarkUnhealthy::class, function (SpeedtestBenchmarkUnhealthy $event) {
+            return $event->attempt === 3;
+        });
+    });
+});

--- a/tests/Feature/CheckForInternetConnectionJobTest.php
+++ b/tests/Feature/CheckForInternetConnectionJobTest.php
@@ -149,4 +149,42 @@ describe('CheckForInternetConnectionJob', function () {
         expect($result->data['message'])->toBe('Ping command is unavailable and HTTP fallback also failed.');
         Event::assertDispatched(SpeedtestFailed::class);
     });
+
+    test('constructor defaults to attempt 1 when not specified', function () {
+        $result = Result::factory()->create();
+
+        $job = new CheckForInternetConnectionJob($result);
+
+        expect($job->attempt)->toBe(1);
+    });
+
+    test('dispatches SpeedtestFailed with the current attempt number when both ping and HTTP fallback fail', function () {
+        $result = Result::factory()->create(['status' => ResultStatus::Started]);
+
+        $failedPing = PingResult::fromArray([
+            'success' => false,
+            'error' => 'hostUnreachable',
+            'host' => 'icanhazip.com',
+        ]);
+        app()->bind(PingHostname::class, fn () => new class($failedPing)
+        {
+            public function __construct(private PingResult $ping) {}
+
+            public function handle(?string $hostname = null, int $count = 1): ?PingResult
+            {
+                return $this->ping;
+            }
+        });
+
+        Http::fake([
+            '*' => Http::response('Service Unavailable', 503),
+        ]);
+
+        [$job, $batch] = (new CheckForInternetConnectionJob($result, 2))->withFakeBatch();
+        $job->handle();
+
+        Event::assertDispatched(SpeedtestFailed::class, function (SpeedtestFailed $event) {
+            return $event->attempt === 2;
+        });
+    });
 });

--- a/tests/Feature/ProcessFailedSpeedtestTest.php
+++ b/tests/Feature/ProcessFailedSpeedtestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Events\SpeedtestFailed;
+use App\Listeners\ProcessFailedSpeedtest;
+use App\Models\Result;
+use Illuminate\Support\Facades\Config;
+
+describe('ProcessFailedSpeedtest', function () {
+    it('returns early without error for an attempt that will still be retried', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestFailed($result, 1);
+
+        expect(fn () => (new ProcessFailedSpeedtest)->handle($event))->not->toThrow(Throwable::class);
+    });
+
+    it('returns without error on the final attempt when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestFailed($result, 1);
+
+        expect(fn () => (new ProcessFailedSpeedtest)->handle($event))->not->toThrow(Throwable::class);
+    });
+});

--- a/tests/Feature/ProcessFailedSpeedtestTest.php
+++ b/tests/Feature/ProcessFailedSpeedtestTest.php
@@ -15,6 +15,15 @@ describe('ProcessFailedSpeedtest', function () {
         expect(fn () => (new ProcessFailedSpeedtest)->handle($event))->not->toThrow(Throwable::class);
     });
 
+    it('returns early without error when the attempt equals the retry limit', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestFailed($result, 3);
+
+        expect(fn () => (new ProcessFailedSpeedtest)->handle($event))->not->toThrow(Throwable::class);
+    });
+
     it('returns without error on the final attempt when retries are disabled', function () {
         Config::set('speedtest.retry_times', 0);
 

--- a/tests/Feature/ProcessUnhealthySpeedtestTest.php
+++ b/tests/Feature/ProcessUnhealthySpeedtestTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use App\Listeners\ProcessUnhealthySpeedtest;
+use App\Mail\UnhealthySpeedtestMail;
+use App\Models\Result;
+use App\Models\User;
+use App\Settings\NotificationSettings;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    $settings = app(NotificationSettings::class);
+    $settings->database_enabled = true;
+    $settings->database_on_threshold_failure = true;
+    $settings->mail_enabled = true;
+    $settings->mail_on_threshold_failure = true;
+    $settings->mail_recipients = ['alerts@example.com'];
+    $settings->save();
+
+    Mail::fake();
+    Notification::fake();
+});
+
+describe('ProcessUnhealthySpeedtest', function () {
+    it('does not notify for an attempt that will still be retried', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        app(ProcessUnhealthySpeedtest::class)->handle($event);
+
+        Mail::assertNothingOutgoing();
+        Notification::assertNothingSentTo($user);
+    });
+
+    it('notifies on the final attempt when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        app(ProcessUnhealthySpeedtest::class)->handle($event);
+
+        Mail::assertQueued(UnhealthySpeedtestMail::class);
+        Notification::assertSentTo($user, DatabaseNotification::class);
+    });
+});

--- a/tests/Feature/ProcessUnhealthySpeedtestTest.php
+++ b/tests/Feature/ProcessUnhealthySpeedtestTest.php
@@ -38,6 +38,19 @@ describe('ProcessUnhealthySpeedtest', function () {
         Notification::assertNothingSentTo($user);
     });
 
+    it('does not notify when the attempt equals the retry limit', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 3);
+
+        app(ProcessUnhealthySpeedtest::class)->handle($event);
+
+        Mail::assertNothingOutgoing();
+        Notification::assertNothingSentTo($user);
+    });
+
     it('notifies on the final attempt when retries are disabled', function () {
         Config::set('speedtest.retry_times', 0);
 

--- a/tests/Feature/RetryFailedSpeedtestTest.php
+++ b/tests/Feature/RetryFailedSpeedtestTest.php
@@ -5,8 +5,10 @@ use App\Jobs\Ookla\RunSpeedtestJob;
 use App\Listeners\RetryFailedSpeedtest;
 use App\Models\Result;
 use Illuminate\Bus\PendingBatch;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     Bus::fake();
@@ -16,9 +18,48 @@ describe('RetryFailedSpeedtest', function () {
     it('delays by the configured retry delay', function () {
         Config::set('speedtest.retry_delay', 42);
 
-        $listener = new RetryFailedSpeedtest;
+        $event = new SpeedtestFailed(Result::factory()->create(['scheduled' => true]), 1);
 
-        expect($listener->delay)->toBe(42);
+        expect((new RetryFailedSpeedtest)->withDelay($event))->toBe(42);
+    });
+
+    it('queues the listener with the configured delay when the event is dispatched for real', function () {
+        Config::set('speedtest.retry_delay', 7);
+        Config::set('speedtest.retry_times', 3);
+
+        // QueueFake::laterOn() discards its $delay argument, so the real
+        // delay can't be observed through Queue::fake(). Mock the resolved
+        // connection instead to capture what the dispatcher actually sends.
+        $capturedDelay = null;
+        $connection = Mockery::mock();
+        $connection->shouldReceive('laterOn')
+            ->once()
+            ->withArgs(function ($queue, $delay, $job) use (&$capturedDelay) {
+                $capturedDelay = $delay;
+
+                return $job instanceof CallQueuedListener && $job->class === RetryFailedSpeedtest::class;
+            });
+        Queue::shouldReceive('connection')->andReturn($connection);
+
+        SpeedtestFailed::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect($capturedDelay)->toBe(7);
+    });
+
+    it('should be queued when retries remain', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $event = new SpeedtestFailed(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryFailedSpeedtest)->shouldQueue($event))->toBeTrue();
+    });
+
+    it('should not be queued when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $event = new SpeedtestFailed(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryFailedSpeedtest)->shouldQueue($event))->toBeFalse();
     });
 
     it('dispatches another attempt when retries remain', function () {

--- a/tests/Feature/RetryFailedSpeedtestTest.php
+++ b/tests/Feature/RetryFailedSpeedtestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Events\SpeedtestFailed;
+use App\Jobs\Ookla\RunSpeedtestJob;
+use App\Listeners\RetryFailedSpeedtest;
+use App\Models\Result;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Bus::fake();
+});
+
+describe('RetryFailedSpeedtest', function () {
+    it('delays by the configured retry delay', function () {
+        Config::set('speedtest.retry_delay', 42);
+
+        $listener = new RetryFailedSpeedtest;
+
+        expect($listener->delay)->toBe(42);
+    });
+
+    it('dispatches another attempt when retries remain', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestFailed($result, 1);
+
+        (new RetryFailedSpeedtest)->handle($event);
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            return $batch->jobs->flatten()->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 2;
+        });
+    });
+
+    it('does not dispatch when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestFailed($result, 1);
+
+        (new RetryFailedSpeedtest)->handle($event);
+
+        Bus::assertNothingBatched();
+    });
+});

--- a/tests/Feature/RetryFailedSpeedtestTest.php
+++ b/tests/Feature/RetryFailedSpeedtestTest.php
@@ -23,6 +23,14 @@ describe('RetryFailedSpeedtest', function () {
         expect((new RetryFailedSpeedtest)->withDelay($event))->toBe(42);
     });
 
+    it('clamps a negative retry delay to zero', function () {
+        Config::set('speedtest.retry_delay', -5);
+
+        $event = new SpeedtestFailed(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryFailedSpeedtest)->withDelay($event))->toBe(0);
+    });
+
     it('queues the listener with the configured delay when the event is dispatched for real', function () {
         Config::set('speedtest.retry_delay', 7);
         Config::set('speedtest.retry_times', 3);

--- a/tests/Feature/RetryUnhealthySpeedtestTest.php
+++ b/tests/Feature/RetryUnhealthySpeedtestTest.php
@@ -5,8 +5,10 @@ use App\Jobs\Ookla\RunSpeedtestJob;
 use App\Listeners\RetryUnhealthySpeedtest;
 use App\Models\Result;
 use Illuminate\Bus\PendingBatch;
+use Illuminate\Events\CallQueuedListener;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Queue;
 
 beforeEach(function () {
     Bus::fake();
@@ -16,9 +18,48 @@ describe('RetryUnhealthySpeedtest', function () {
     it('delays by the configured retry delay', function () {
         Config::set('speedtest.retry_delay', 42);
 
-        $listener = new RetryUnhealthySpeedtest;
+        $event = new SpeedtestBenchmarkUnhealthy(Result::factory()->create(['scheduled' => true]), 1);
 
-        expect($listener->delay)->toBe(42);
+        expect((new RetryUnhealthySpeedtest)->withDelay($event))->toBe(42);
+    });
+
+    it('queues the listener with the configured delay when the event is dispatched for real', function () {
+        Config::set('speedtest.retry_delay', 7);
+        Config::set('speedtest.retry_times', 3);
+
+        // QueueFake::laterOn() discards its $delay argument, so the real
+        // delay can't be observed through Queue::fake(). Mock the resolved
+        // connection instead to capture what the dispatcher actually sends.
+        $capturedDelay = null;
+        $connection = Mockery::mock();
+        $connection->shouldReceive('laterOn')
+            ->once()
+            ->withArgs(function ($queue, $delay, $job) use (&$capturedDelay) {
+                $capturedDelay = $delay;
+
+                return $job instanceof CallQueuedListener && $job->class === RetryUnhealthySpeedtest::class;
+            });
+        Queue::shouldReceive('connection')->andReturn($connection);
+
+        SpeedtestBenchmarkUnhealthy::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect($capturedDelay)->toBe(7);
+    });
+
+    it('should be queued when retries remain', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $event = new SpeedtestBenchmarkUnhealthy(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryUnhealthySpeedtest)->shouldQueue($event))->toBeTrue();
+    });
+
+    it('should not be queued when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $event = new SpeedtestBenchmarkUnhealthy(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryUnhealthySpeedtest)->shouldQueue($event))->toBeFalse();
     });
 
     it('dispatches another attempt when retries remain', function () {

--- a/tests/Feature/RetryUnhealthySpeedtestTest.php
+++ b/tests/Feature/RetryUnhealthySpeedtestTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use App\Jobs\Ookla\RunSpeedtestJob;
+use App\Listeners\RetryUnhealthySpeedtest;
+use App\Models\Result;
+use Illuminate\Bus\PendingBatch;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Bus::fake();
+});
+
+describe('RetryUnhealthySpeedtest', function () {
+    it('delays by the configured retry delay', function () {
+        Config::set('speedtest.retry_delay', 42);
+
+        $listener = new RetryUnhealthySpeedtest;
+
+        expect($listener->delay)->toBe(42);
+    });
+
+    it('dispatches another attempt when retries remain', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        (new RetryUnhealthySpeedtest)->handle($event);
+
+        Bus::assertBatched(function (PendingBatch $batch) {
+            return $batch->jobs->flatten()->first(fn ($job) => $job instanceof RunSpeedtestJob)?->attempt === 2;
+        });
+    });
+
+    it('does not dispatch when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $result = Result::factory()->create(['scheduled' => true]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        (new RetryUnhealthySpeedtest)->handle($event);
+
+        Bus::assertNothingBatched();
+    });
+});

--- a/tests/Feature/RetryUnhealthySpeedtestTest.php
+++ b/tests/Feature/RetryUnhealthySpeedtestTest.php
@@ -23,6 +23,14 @@ describe('RetryUnhealthySpeedtest', function () {
         expect((new RetryUnhealthySpeedtest)->withDelay($event))->toBe(42);
     });
 
+    it('clamps a negative retry delay to zero', function () {
+        Config::set('speedtest.retry_delay', -5);
+
+        $event = new SpeedtestBenchmarkUnhealthy(Result::factory()->create(['scheduled' => true]), 1);
+
+        expect((new RetryUnhealthySpeedtest)->withDelay($event))->toBe(0);
+    });
+
     it('queues the listener with the configured delay when the event is dispatched for real', function () {
         Config::set('speedtest.retry_delay', 7);
         Config::set('speedtest.retry_times', 3);

--- a/tests/Feature/RunSpeedtestJobTest.php
+++ b/tests/Feature/RunSpeedtestJobTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Jobs\Ookla\RunSpeedtestJob;
+use App\Models\Result;
+
+describe('RunSpeedtestJob', function () {
+    test('defaults to attempt 1 when not specified', function () {
+        $result = Result::factory()->create();
+
+        $job = new RunSpeedtestJob($result);
+
+        expect($job->attempt)->toBe(1);
+    });
+
+    test('accepts and stores a specific attempt number', function () {
+        $result = Result::factory()->create();
+
+        $job = new RunSpeedtestJob($result, 3);
+
+        expect($job->attempt)->toBe(3);
+    });
+});

--- a/tests/Feature/SkipSpeedtestJobTest.php
+++ b/tests/Feature/SkipSpeedtestJobTest.php
@@ -1,0 +1,51 @@
+<?php
+
+use App\Enums\ResultStatus;
+use App\Events\SpeedtestFailed;
+use App\Jobs\Ookla\SkipSpeedtestJob;
+use App\Models\Result;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Event::fake();
+});
+
+describe('SkipSpeedtestJob', function () {
+    test('defaults to attempt 1 when not specified', function () {
+        $result = Result::factory()->create();
+
+        $job = new SkipSpeedtestJob($result);
+
+        expect($job->attempt)->toBe(1);
+    });
+
+    test('accepts and stores a specific attempt number', function () {
+        $result = Result::factory()->create();
+
+        $job = new SkipSpeedtestJob($result, 2);
+
+        expect($job->attempt)->toBe(2);
+    });
+
+    test('dispatches SpeedtestFailed with the current attempt number when the external IP lookup fails', function () {
+        Config::set('speedtest.preflight.skip_ips', '1.2.3.4');
+
+        $result = Result::factory()->create(['scheduled' => true]);
+
+        Http::fake([
+            '*' => Http::response('', 503),
+        ]);
+
+        [$job, $batch] = (new SkipSpeedtestJob($result, 4))->withFakeBatch();
+        $job->handle();
+
+        $this->assertTrue($batch->cancelled());
+        $result->refresh();
+        expect($result->status)->toBe(ResultStatus::Failed);
+        Event::assertDispatched(SpeedtestFailed::class, function (SpeedtestFailed $event) {
+            return $event->attempt === 4;
+        });
+    });
+});

--- a/tests/Feature/UserNotificationSubscriberTest.php
+++ b/tests/Feature/UserNotificationSubscriberTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Events\SpeedtestBenchmarkUnhealthy;
+use App\Events\SpeedtestFailed;
+use App\Listeners\UserNotificationSubscriber;
+use App\Models\Result;
+use App\Models\User;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
+
+beforeEach(function () {
+    Notification::fake();
+});
+
+describe('UserNotificationSubscriber::handleFailed', function () {
+    it('does not notify for an attempt that will still be retried', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestFailed($result, 1);
+
+        (new UserNotificationSubscriber)->handleFailed($event);
+
+        Notification::assertNothingSentTo($user);
+    });
+
+    it('notifies on the final attempt when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestFailed($result, 1);
+
+        (new UserNotificationSubscriber)->handleFailed($event);
+
+        Notification::assertSentTo($user, DatabaseNotification::class);
+    });
+});
+
+describe('UserNotificationSubscriber::handleBenchmarkFailed', function () {
+    it('does not notify for an attempt that will still be retried', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        (new UserNotificationSubscriber)->handleBenchmarkFailed($event);
+
+        Notification::assertNothingSentTo($user);
+    });
+
+    it('notifies on the final attempt when retries are disabled', function () {
+        Config::set('speedtest.retry_times', 0);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        (new UserNotificationSubscriber)->handleBenchmarkFailed($event);
+
+        Notification::assertSentTo($user, DatabaseNotification::class);
+    });
+});

--- a/tests/Feature/UserNotificationSubscriberTest.php
+++ b/tests/Feature/UserNotificationSubscriberTest.php
@@ -26,6 +26,18 @@ describe('UserNotificationSubscriber::handleFailed', function () {
         Notification::assertNothingSentTo($user);
     });
 
+    it('does not notify when the attempt equals the retry limit', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestFailed($result, 3);
+
+        (new UserNotificationSubscriber)->handleFailed($event);
+
+        Notification::assertNothingSentTo($user);
+    });
+
     it('notifies on the final attempt when retries are disabled', function () {
         Config::set('speedtest.retry_times', 0);
 
@@ -46,6 +58,18 @@ describe('UserNotificationSubscriber::handleBenchmarkFailed', function () {
         $user = User::factory()->create();
         $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
         $event = new SpeedtestBenchmarkUnhealthy($result, 1);
+
+        (new UserNotificationSubscriber)->handleBenchmarkFailed($event);
+
+        Notification::assertNothingSentTo($user);
+    });
+
+    it('does not notify when the attempt equals the retry limit', function () {
+        Config::set('speedtest.retry_times', 3);
+
+        $user = User::factory()->create();
+        $result = Result::factory()->create(['scheduled' => true, 'dispatched_by' => $user->id]);
+        $event = new SpeedtestBenchmarkUnhealthy($result, 3);
 
         (new UserNotificationSubscriber)->handleBenchmarkFailed($event);
 

--- a/tests/Feature/Webhooks/DispatchWebhooksTest.php
+++ b/tests/Feature/Webhooks/DispatchWebhooksTest.php
@@ -1,10 +1,13 @@
 <?php
 
 use App\Enums\WebhookEvent;
+use App\Events\SpeedtestBenchmarkUnhealthy;
 use App\Events\SpeedtestCompleted;
+use App\Events\SpeedtestFailed;
 use App\Models\Result;
 use App\Models\Webhook;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Config;
 use Spatie\WebhookServer\CallWebhookJob;
 
 beforeEach(function () {
@@ -48,6 +51,46 @@ it('dispatches a signed webhook when a secret is set', function () {
     ]);
 
     SpeedtestCompleted::dispatch(Result::factory()->create());
+
+    Bus::assertDispatchedTimes(CallWebhookJob::class, 1);
+});
+
+it('does not dispatch webhooks for a failed attempt that will still be retried', function () {
+    Config::set('speedtest.retry_times', 3);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::Failed->value]]);
+
+    SpeedtestFailed::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+    Bus::assertNotDispatched(CallWebhookJob::class);
+});
+
+it('dispatches webhooks on the final failed attempt when retries are disabled', function () {
+    Config::set('speedtest.retry_times', 0);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::Failed->value]]);
+
+    SpeedtestFailed::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+    Bus::assertDispatchedTimes(CallWebhookJob::class, 1);
+});
+
+it('does not dispatch webhooks for a benchmark-unhealthy attempt that will still be retried', function () {
+    Config::set('speedtest.retry_times', 3);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::BenchmarkUnhealthy->value]]);
+
+    SpeedtestBenchmarkUnhealthy::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+    Bus::assertNotDispatched(CallWebhookJob::class);
+});
+
+it('dispatches webhooks on the final benchmark-unhealthy attempt when retries are disabled', function () {
+    Config::set('speedtest.retry_times', 0);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::BenchmarkUnhealthy->value]]);
+
+    SpeedtestBenchmarkUnhealthy::dispatch(Result::factory()->create(['scheduled' => true]), 1);
 
     Bus::assertDispatchedTimes(CallWebhookJob::class, 1);
 });

--- a/tests/Feature/Webhooks/DispatchWebhooksTest.php
+++ b/tests/Feature/Webhooks/DispatchWebhooksTest.php
@@ -65,6 +65,16 @@ it('does not dispatch webhooks for a failed attempt that will still be retried',
     Bus::assertNotDispatched(CallWebhookJob::class);
 });
 
+it('does not dispatch webhooks for a failed attempt that equals the retry limit', function () {
+    Config::set('speedtest.retry_times', 3);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::Failed->value]]);
+
+    SpeedtestFailed::dispatch(Result::factory()->create(['scheduled' => true]), 3);
+
+    Bus::assertNotDispatched(CallWebhookJob::class);
+});
+
 it('dispatches webhooks on the final failed attempt when retries are disabled', function () {
     Config::set('speedtest.retry_times', 0);
 
@@ -85,12 +95,32 @@ it('does not dispatch webhooks for a benchmark-unhealthy attempt that will still
     Bus::assertNotDispatched(CallWebhookJob::class);
 });
 
+it('does not dispatch webhooks for a benchmark-unhealthy attempt that equals the retry limit', function () {
+    Config::set('speedtest.retry_times', 3);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::BenchmarkUnhealthy->value]]);
+
+    SpeedtestBenchmarkUnhealthy::dispatch(Result::factory()->create(['scheduled' => true]), 3);
+
+    Bus::assertNotDispatched(CallWebhookJob::class);
+});
+
 it('dispatches webhooks on the final benchmark-unhealthy attempt when retries are disabled', function () {
     Config::set('speedtest.retry_times', 0);
 
     Webhook::factory()->create(['events' => [WebhookEvent::BenchmarkUnhealthy->value]]);
 
     SpeedtestBenchmarkUnhealthy::dispatch(Result::factory()->create(['scheduled' => true]), 1);
+
+    Bus::assertDispatchedTimes(CallWebhookJob::class, 1);
+});
+
+it('dispatches webhooks for an attempt-less event even while retries are active', function () {
+    Config::set('speedtest.retry_times', 3);
+
+    Webhook::factory()->create(['events' => [WebhookEvent::Completed->value]]);
+
+    SpeedtestCompleted::dispatch(Result::factory()->create());
 
     Bus::assertDispatchedTimes(CallWebhookJob::class, 1);
 });


### PR DESCRIPTION
## Summary

Adds automatic retry when a speedtest fails or completes below your configured thresholds. Fully opt-in via two new `.env` values — existing installs are unaffected by default.

- `SPEEDTEST_RETRY_TIMES` (default `0` = disabled) — number of additional attempts after the first failure. `3` means up to 4 total runs.
- `SPEEDTEST_RETRY_DELAY` (default `5`, seconds) — wait time before each retry.

A retry triggers on either failure mode the app already tracks: a process error (`Result.status = Failed` — e.g. the CLI errors out, connectivity check fails, external-IP lookup fails) or a threshold breach (`Result.healthy = false`). Every attempt is kept as its own `Result` row, same as today — nothing is discarded or merged.

## Design notes

A couple of behavior decisions worth flagging explicitly rather than leaving implicit in the diff:

- **Retries reuse the server from the failed attempt** rather than re-running server selection. This was a deliberate choice, not an oversight — happy to discuss if you'd prefer retries to re-select.
- **Notifications (email, Apprise, Filament alerts, webhooks) are suppressed for attempts that will still be retried** — only the final attempt notifies. Without this, `SPEEDTEST_RETRY_TIMES=3` would mean 4x the alert noise for one logical failure.

## Implementation

- `attempt` (default `1`) is threaded through the 4 job classes that can fire `SpeedtestFailed`/`SpeedtestBenchmarkUnhealthy` (`RunSpeedtestJob`, `BenchmarkSpeedtestJob`, `SkipSpeedtestJob`, `CheckForInternetConnectionJob`) and through those two event classes.
- Two new queued listeners (`RetryFailedSpeedtest`, `RetryUnhealthySpeedtest`) delay by the configured seconds, then hand off to a new `RetrySpeedtest` action, which decides whether attempts remain and re-invokes the existing `RunSpeedtest` action — the single entry point both scheduled and manual runs already go through.
- No database migrations — config only.

## Testing

- 128 automated tests (Pest), covering the retry decision logic, attempt-threading across all 4 failure-dispatching jobs, the notification-suppression boundary, and the queue delay itself.
- Manually verified end-to-end: forced a guaranteed threshold failure, watched 3 total attempts land ~10s apart via a live `queue:work` worker, and confirmed notifications only fired on the final attempt. Also confirmed `SPEEDTEST_RETRY_TIMES=0` produces exactly the pre-existing single-attempt behavior.