### PR TITLE
Feat: Add all the chart settings to Settings table

### DIFF
--- a/app/Filament/Pages/Settings/General.php
+++ b/app/Filament/Pages/Settings/General.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Pages\Settings;
 
 use App\Settings\GeneralSettings;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\SettingsPage;
 use Filament\Schemas\Components\Grid;
@@ -11,6 +12,7 @@ use Filament\Schemas\Components\Tabs\Tab;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\HtmlString;
 
 class General extends SettingsPage
 {
@@ -53,12 +55,23 @@ class General extends SettingsPage
                             ->schema([
                                 Grid::make(['default' => 1, 'md' => 2])
                                     ->schema([
-                                        TextInput::make('default_chart_range')
-                                            ->label(__('settings/general.default_chart_range'))
-                                            ->helperText(__('settings/general.default_chart_range_helper_text'))
+                                        TextInput::make('chart_default_range')
+                                            ->label(__('settings/general.chart_default_range'))
+                                            ->helperText(__('settings/general.chart_default_range_helper_text'))
                                             ->numeric()
                                             ->minValue(1)
                                             ->required(),
+                                        TextInput::make('chart_datetime_format')
+                                            ->label(__('settings/general.chart_datetime_format'))
+                                            ->helperText(__('settings/general.chart_datetime_format_helper_text'))
+                                            ->hint(new HtmlString('&#x1f517;<a href="https://www.php.net/manual/en/datetime.format.php" target="_blank" rel="nofollow">'.__('settings/general.datetime_format_docs').'</a>'))
+                                            ->required(),
+                                        Checkbox::make('chart_begin_at_zero')
+                                            ->label(__('settings/general.chart_begin_at_zero'))
+                                            ->helperText(__('settings/general.chart_begin_at_zero_helper_text')),
+                                        Checkbox::make('chart_only_show_avg_latency')
+                                            ->label(__('settings/general.chart_only_show_avg_latency'))
+                                            ->helperText(__('settings/general.chart_only_show_avg_latency_helper_text')),
                                     ]),
                             ])
                             ->columnSpanFull(),

--- a/app/Filament/Widgets/Concerns/HasChartFilters.php
+++ b/app/Filament/Widgets/Concerns/HasChartFilters.php
@@ -47,6 +47,6 @@ trait HasChartFilters
 
     protected function defaultStartDate(): Carbon
     {
-        return now()->subDays(app(GeneralSettings::class)->default_chart_range);
+        return now()->subDays(app(GeneralSettings::class)->chart_default_range);
     }
 }

--- a/app/Filament/Widgets/RecentDownloadChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadChartWidget extends ChartWidget
@@ -61,7 +62,7 @@ class RecentDownloadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -82,7 +83,7 @@ class RecentDownloadChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentDownloadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentDownloadLatencyChartWidget extends ChartWidget
@@ -49,7 +50,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ],
         ];
 
-        if (! config('speedtest.chart_only_show_avg_latency')) {
+        if (! app(GeneralSettings::class)->chart_only_show_avg_latency) {
             $datasets[] = [
                 'label' => __('general.high_ms'),
                 'data' => $results->map(fn ($item) => $item->download_latency_high),
@@ -77,7 +78,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
 
         return [
             'datasets' => $datasets,
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -97,7 +98,7 @@ class RecentDownloadLatencyChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentJitterChartWidget.php
+++ b/app/Filament/Widgets/RecentJitterChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentJitterChartWidget extends ChartWidget
@@ -71,7 +72,7 @@ class RecentJitterChartWidget extends ChartWidget
                     'pointRadius' => count($results) <= 24 ? 3 : 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -91,7 +92,7 @@ class RecentJitterChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                 ],
             ],
         ];

--- a/app/Filament/Widgets/RecentPingChartWidget.php
+++ b/app/Filament/Widgets/RecentPingChartWidget.php
@@ -6,6 +6,7 @@ use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentPingChartWidget extends ChartWidget
@@ -60,7 +61,7 @@ class RecentPingChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -80,7 +81,7 @@ class RecentPingChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentUploadChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadChartWidget.php
@@ -7,6 +7,7 @@ use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Helpers\Average;
 use App\Helpers\Number;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadChartWidget extends ChartWidget
@@ -61,7 +62,7 @@ class RecentUploadChartWidget extends ChartWidget
                     'pointRadius' => 0,
                 ],
             ],
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -81,7 +82,7 @@ class RecentUploadChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
+++ b/app/Filament/Widgets/RecentUploadLatencyChartWidget.php
@@ -5,6 +5,7 @@ namespace App\Filament\Widgets;
 use App\Enums\ResultStatus;
 use App\Filament\Widgets\Concerns\HasChartFilters;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Filament\Widgets\ChartWidget;
 
 class RecentUploadLatencyChartWidget extends ChartWidget
@@ -49,7 +50,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ],
         ];
 
-        if (! config('speedtest.chart_only_show_avg_latency')) {
+        if (! app(GeneralSettings::class)->chart_only_show_avg_latency) {
             $datasets[] = [
                 'label' => __('general.high_ms'),
                 'data' => $results->map(fn ($item) => $item->upload_latency_high),
@@ -77,7 +78,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
 
         return [
             'datasets' => $datasets,
-            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(config('app.chart_datetime_format'))),
+            'labels' => $results->map(fn ($item) => $item->created_at->timezone(config('app.display_timezone'))->format(app(GeneralSettings::class)->chart_datetime_format)),
         ];
     }
 
@@ -97,7 +98,7 @@ class RecentUploadLatencyChartWidget extends ChartWidget
             ],
             'scales' => [
                 'y' => [
-                    'beginAtZero' => config('app.chart_begin_at_zero'),
+                    'beginAtZero' => app(GeneralSettings::class)->chart_begin_at_zero,
                     'grace' => 2,
                 ],
             ],

--- a/app/Livewire/DateRangeFilter.php
+++ b/app/Livewire/DateRangeFilter.php
@@ -22,7 +22,7 @@ class DateRangeFilter extends Component implements HasForms
 
     public function mount(): void
     {
-        $this->dateFrom = now()->subDays(app(GeneralSettings::class)->default_chart_range)->toDateTimeString();
+        $this->dateFrom = now()->subDays(app(GeneralSettings::class)->chart_default_range)->toDateTimeString();
         $this->dateTo = now()->toDateTimeString();
 
         $this->form->fill([

--- a/app/Settings/GeneralSettings.php
+++ b/app/Settings/GeneralSettings.php
@@ -6,7 +6,13 @@ use Spatie\LaravelSettings\Settings;
 
 class GeneralSettings extends Settings
 {
-    public int $default_chart_range;
+    public int $chart_default_range;
+
+    public bool $chart_begin_at_zero;
+
+    public string $chart_datetime_format;
+
+    public bool $chart_only_show_avg_latency;
 
     public static function group(): string
     {

--- a/config/app.php
+++ b/config/app.php
@@ -125,21 +125,6 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
-    // TODO: move to speedtest.php configuration file
-
-    /*
-    |--------------------------------------------------------------------------
-    | Chart Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the default settings for charts used in the application.
-    |
-    */
-
-    'chart_begin_at_zero' => env('CHART_BEGIN_AT_ZERO', true),
-
-    'chart_datetime_format' => env('CHART_DATETIME_FORMAT', 'M. j - G:i'),
-
     /*
     |--------------------------------------------------------------------------
     | Display Configuration

--- a/config/app.php
+++ b/config/app.php
@@ -67,7 +67,7 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', 'UTC'),
+    'timezone' => env('APP_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------
@@ -136,7 +136,7 @@ return [
 
     'datetime_format' => env('DATETIME_FORMAT', 'M. j, Y g:ia'),
 
-    'display_timezone' => env('DISPLAY_TIMEZONE', 'UTC'),
+    'display_timezone' => env('DISPLAY_TIMEZONE') ?? env('TZ', 'UTC'),
 
     /*
     |--------------------------------------------------------------------------

--- a/config/speedtest.php
+++ b/config/speedtest.php
@@ -16,7 +16,14 @@ return [
 
     'public_dashboard' => env('PUBLIC_DASHBOARD', false),
 
-    'default_chart_range_days' => (int) env('DEFAULT_CHART_RANGE_DAYS', 7),
+    /**
+     * Chart settings.
+     */
+    'chart_begin_at_zero' => env('CHART_BEGIN_AT_ZERO', true),
+
+    'chart_datetime_format' => env('CHART_DATETIME_FORMAT', 'M. j - G:i'),
+
+    'chart_default_range_days' => (int) env('CHART_DEFAULT_RANGE_DAYS', 7),
 
     'chart_only_show_avg_latency' => (bool) env('CHART_ONLY_SHOW_AVG_LATENCY', false),
 

--- a/database/seeders/ResultSeeder.php
+++ b/database/seeders/ResultSeeder.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\ResultService;
+use App\Enums\ResultStatus;
+use App\Models\Result;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+class ResultSeeder extends Seeder
+{
+    /**
+     * Number of hourly results to generate, working backwards from now.
+     */
+    private const int HOURS = 24 * 30;
+
+    /**
+     * Seed the results table with one completed result per hour.
+     */
+    public function run(): void
+    {
+        $now = Carbon::now();
+
+        collect(range(0, self::HOURS - 1))
+            ->map(fn (int $hoursAgo) => $this->makeResult($now->copy()->subHours($hoursAgo)))
+            ->chunk(100)
+            ->each(fn ($chunk) => Result::insert($chunk->all()));
+    }
+
+    /**
+     * Build a single result row.
+     *
+     * @return array<string, mixed>
+     */
+    private function makeResult(Carbon $timestamp): array
+    {
+        $ping = fake()->randomFloat(3, 10, 100);
+        $pingJitter = fake()->randomFloat(3, 2, 10);
+        [$pingLow, $pingHigh] = $this->spread($ping, 10, 100);
+
+        $downloadMbps = fake()->randomFloat(2, 800, 950);
+        $uploadMbps = fake()->randomFloat(2, 800, 950);
+        $downloadBandwidth = (int) round($downloadMbps * 1_000_000 / 8);
+        $uploadBandwidth = (int) round($uploadMbps * 1_000_000 / 8);
+        $downloadBytes = $downloadBandwidth * 10;
+        $uploadBytes = $uploadBandwidth * 10;
+
+        $downloadLatencyIqm = fake()->randomFloat(3, 1, 100);
+        [$downloadLatencyLow, $downloadLatencyHigh] = $this->spread($downloadLatencyIqm, 1, 100);
+        $downloadJitter = fake()->randomFloat(3, 2, 10);
+
+        $uploadLatencyIqm = fake()->randomFloat(3, 1, 100);
+        [$uploadLatencyLow, $uploadLatencyHigh] = $this->spread($uploadLatencyIqm, 1, 100);
+        $uploadJitter = fake()->randomFloat(3, 2, 10);
+
+        $data = [
+            'isp' => 'Speedtest Communications',
+            'ping' => [
+                'low' => $pingLow,
+                'high' => $pingHigh,
+                'jitter' => $pingJitter,
+                'latency' => $ping,
+            ],
+            'type' => 'result',
+            'result' => [
+                'id' => (string) Str::uuid(),
+                'url' => 'https://docs.speedtest-tracker.dev',
+                'persisted' => true,
+            ],
+            'server' => [
+                'id' => 0,
+                'ip' => '127.0.0.1',
+                'host' => 'docs.speedtest-tracker.dev',
+                'name' => 'Speedtest',
+                'port' => 8080,
+                'country' => 'United States',
+                'location' => 'New York City, NY',
+            ],
+            'upload' => [
+                'bytes' => $uploadBytes,
+                'elapsed' => 10000,
+                'latency' => [
+                    'iqm' => $uploadLatencyIqm,
+                    'low' => $uploadLatencyLow,
+                    'high' => $uploadLatencyHigh,
+                    'jitter' => $uploadJitter,
+                ],
+                'bandwidth' => $uploadBandwidth,
+            ],
+            'download' => [
+                'bytes' => $downloadBytes,
+                'elapsed' => 10000,
+                'latency' => [
+                    'iqm' => $downloadLatencyIqm,
+                    'low' => $downloadLatencyLow,
+                    'high' => $downloadLatencyHigh,
+                    'jitter' => $downloadJitter,
+                ],
+                'bandwidth' => $downloadBandwidth,
+            ],
+            'interface' => [
+                'name' => 'eth0',
+                'isVpn' => false,
+                'macAddr' => '00:00:00:00:00:00',
+                'externalIp' => '127.0.0.1',
+                'internalIp' => '127.0.0.1',
+            ],
+            'timestamp' => $timestamp->toIso8601String(),
+            'packetLoss' => 0,
+        ];
+
+        return [
+            'service' => ResultService::Faker->value,
+            'ping' => $ping,
+            'download' => $downloadBandwidth,
+            'upload' => $uploadBandwidth,
+            'download_bytes' => $downloadBytes,
+            'upload_bytes' => $uploadBytes,
+            'data' => json_encode($data),
+            'status' => ResultStatus::Completed->value,
+            'scheduled' => true,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ];
+    }
+
+    /**
+     * Spread a low/high pair around a center value, clamped to the given bounds.
+     *
+     * @return array{0: float, 1: float}
+     */
+    private function spread(float $center, float $min, float $max): array
+    {
+        $low = max($min, $center - fake()->randomFloat(2, 0, 20));
+        $high = min($max, $center + fake()->randomFloat(2, 0, 20));
+
+        return [round($low, 3), round($high, 3)];
+    }
+}

--- a/database/settings/2026_06_28_000000_create_general_settings.php
+++ b/database/settings/2026_06_28_000000_create_general_settings.php
@@ -6,6 +6,9 @@ return new class extends SettingsMigration
 {
     public function up(): void
     {
-        $this->migrator->add('general.default_chart_range', config('speedtest.default_chart_range_days'));
+        $this->migrator->add('general.chart_default_range', config('speedtest.chart_default_range_days'));
+        $this->migrator->add('general.chart_begin_at_zero', config('speedtest.chart_begin_at_zero'));
+        $this->migrator->add('general.chart_datetime_format', config('speedtest.chart_datetime_format'));
+        $this->migrator->add('general.chart_only_show_avg_latency', config('speedtest.chart_only_show_avg_latency'));
     }
 };

--- a/lang/en/settings/general.php
+++ b/lang/en/settings/general.php
@@ -4,8 +4,17 @@ return [
     'title' => 'General',
     'label' => 'General',
 
+    // Display options
+    'datetime_format_docs' => 'Format options',
+
     // Charts section
     'charts' => 'Charts',
-    'default_chart_range' => 'Default chart range (days)',
-    'default_chart_range_helper_text' => 'The number of days shown by default when a chart first loads.',
+    'chart_default_range' => 'Default chart range (days)',
+    'chart_default_range_helper_text' => 'The number of days shown by default when a chart first loads.',
+    'chart_datetime_format' => 'Chart date/time format',
+    'chart_datetime_format_helper_text' => 'The PHP date format used for chart axis labels (e.g. "M. j - G:i").',
+    'chart_begin_at_zero' => 'Begin chart Y-axis at zero',
+    'chart_begin_at_zero_helper_text' => 'When enabled, chart Y-axes always start at zero instead of scaling to the data range.',
+    'chart_only_show_avg_latency' => 'Only show average latency',
+    'chart_only_show_avg_latency_helper_text' => 'When enabled, latency charts show only the average line and hide the high/low datasets.',
 ];

--- a/tests/Feature/Filament/Widgets/LatencyChartWidgetsTest.php
+++ b/tests/Feature/Filament/Widgets/LatencyChartWidgetsTest.php
@@ -3,6 +3,7 @@
 use App\Filament\Widgets\RecentDownloadLatencyChartWidget;
 use App\Filament\Widgets\RecentUploadLatencyChartWidget;
 use App\Models\Result;
+use App\Settings\GeneralSettings;
 use Livewire\Livewire;
 
 function latencyChartDatasetLabels(string $widgetClass): array
@@ -23,7 +24,7 @@ it('shows average, high, and low for download latency by default', function () {
 });
 
 it('shows only average for download latency when chart_only_show_avg_latency is enabled', function () {
-    config(['speedtest.chart_only_show_avg_latency' => true]);
+    app(GeneralSettings::class)->fill(['chart_only_show_avg_latency' => true])->save();
     Result::factory()->create();
 
     expect(latencyChartDatasetLabels(RecentDownloadLatencyChartWidget::class))
@@ -38,7 +39,7 @@ it('shows average, high, and low for upload latency by default', function () {
 });
 
 it('shows only average for upload latency when chart_only_show_avg_latency is enabled', function () {
-    config(['speedtest.chart_only_show_avg_latency' => true]);
+    app(GeneralSettings::class)->fill(['chart_only_show_avg_latency' => true])->save();
     Result::factory()->create();
 
     expect(latencyChartDatasetLabels(RecentUploadLatencyChartWidget::class))

--- a/tests/Feature/GeneralSettingsTest.php
+++ b/tests/Feature/GeneralSettingsTest.php
@@ -34,7 +34,7 @@ describe('form', function () {
 
         Livewire::test(General::class)
             ->assertFormSet([
-                'default_chart_range' => $settings->default_chart_range,
+                'chart_default_range' => $settings->chart_default_range,
             ]);
     });
 
@@ -42,21 +42,64 @@ describe('form', function () {
         $this->actingAs($this->admin);
 
         Livewire::test(General::class)
-            ->fillForm(['default_chart_range' => 7])
+            ->fillForm(['chart_default_range' => 7])
             ->call('save')
             ->assertHasNoFormErrors();
 
         app()->forgetInstance(GeneralSettings::class);
 
-        expect(app(GeneralSettings::class)->default_chart_range)->toBe(7);
+        expect(app(GeneralSettings::class)->chart_default_range)->toBe(7);
     });
 
     it('requires a default chart range', function () {
         $this->actingAs($this->admin);
 
         Livewire::test(General::class)
-            ->fillForm(['default_chart_range' => null])
+            ->fillForm(['chart_default_range' => null])
             ->call('save')
-            ->assertHasFormErrors(['default_chart_range' => 'required']);
+            ->assertHasFormErrors(['chart_default_range' => 'required']);
+    });
+
+    it('loads the current chart display settings into the form', function () {
+        $this->actingAs($this->admin);
+
+        $settings = app(GeneralSettings::class);
+
+        Livewire::test(General::class)
+            ->assertFormSet([
+                'chart_begin_at_zero' => $settings->chart_begin_at_zero,
+                'chart_datetime_format' => $settings->chart_datetime_format,
+                'chart_only_show_avg_latency' => $settings->chart_only_show_avg_latency,
+            ]);
+    });
+
+    it('saves the updated chart display settings to the database', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm([
+                'chart_begin_at_zero' => false,
+                'chart_datetime_format' => 'Y-m-d H:i',
+                'chart_only_show_avg_latency' => true,
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        app()->forgetInstance(GeneralSettings::class);
+
+        $settings = app(GeneralSettings::class);
+
+        expect($settings->chart_begin_at_zero)->toBeFalse()
+            ->and($settings->chart_datetime_format)->toBe('Y-m-d H:i')
+            ->and($settings->chart_only_show_avg_latency)->toBeTrue();
+    });
+
+    it('requires a chart datetime format', function () {
+        $this->actingAs($this->admin);
+
+        Livewire::test(General::class)
+            ->fillForm(['chart_datetime_format' => null])
+            ->call('save')
+            ->assertHasFormErrors(['chart_datetime_format' => 'required']);
     });
 });

--- a/tests/Feature/Livewire/DateRangeFilterTest.php
+++ b/tests/Feature/Livewire/DateRangeFilterTest.php
@@ -18,7 +18,7 @@ afterEach(function () {
 });
 
 it('mounts with the admin-configured default range and broadcasts it', function () {
-    app(GeneralSettings::class)->fill(['default_chart_range' => 7])->save();
+    app(GeneralSettings::class)->fill(['chart_default_range' => 7])->save();
 
     Livewire::test(DateRangeFilter::class)
         ->assertOk()
@@ -29,7 +29,7 @@ it('mounts with the admin-configured default range and broadcasts it', function 
 });
 
 it('broadcasts an updated range when the start date changes', function () {
-    app(GeneralSettings::class)->fill(['default_chart_range' => 1])->save();
+    app(GeneralSettings::class)->fill(['chart_default_range' => 1])->save();
 
     Livewire::test(DateRangeFilter::class)
         ->set('dateFrom', now()->subHours(2)->toDateTimeString())
@@ -37,7 +37,7 @@ it('broadcasts an updated range when the start date changes', function () {
 });
 
 it('normalizes the range so the end date is never before the start date', function () {
-    app(GeneralSettings::class)->fill(['default_chart_range' => 1])->save();
+    app(GeneralSettings::class)->fill(['chart_default_range' => 1])->save();
 
     Livewire::test(DateRangeFilter::class)
         ->set('dateFrom', now()->toDateTimeString())

--- a/tests/Feature/Widgets/RecentDownloadChartWidgetTest.php
+++ b/tests/Feature/Widgets/RecentDownloadChartWidgetTest.php
@@ -18,7 +18,7 @@ use function Pest\Laravel\actingAs;
 beforeEach(function () {
     actingAs(User::factory()->create());
     Carbon::setTestNow(Carbon::parse('2026-07-23 12:00:00'));
-    app(GeneralSettings::class)->fill(['default_chart_range' => 1])->save();
+    app(GeneralSettings::class)->fill(['chart_default_range' => 1])->save();
 });
 
 afterEach(function () {
@@ -51,7 +51,7 @@ it('only includes results within the applied custom date range', function () {
 });
 
 it('falls back to the admin-configured default window when no filter is applied', function () {
-    app(GeneralSettings::class)->fill(['default_chart_range' => 7])->save();
+    app(GeneralSettings::class)->fill(['chart_default_range' => 7])->save();
 
     Result::factory()->create([
         'status' => ResultStatus::Completed,


### PR DESCRIPTION
## 📃 Description

Moves the remaining chart display settings (default range, begin-at-zero, datetime format, average-only latency) out of env-based config and into the database-backed General settings page, so admins can change chart behavior at runtime without editing `.env` or redeploying. Also adds a `ResultSeeder` for generating realistic test data, and fixes timezone env var fallback.

## 📖 Documentation

_No documentation changes required for this PR._

## 🪵 Changelog

### ➕ Added

- Chart settings (`chart_begin_at_zero`, `chart_datetime_format`, `chart_only_show_avg_latency`) to the General settings page, editable by admins at runtime.
- `ResultSeeder` to generate hourly test results with realistic download/upload, ping, jitter, and latency values for local testing.

### ✏️ Changed

- Chart widgets (Download, Upload, Download Latency, Upload Latency, Ping, Jitter) now read their begin-at-zero, datetime format, and avg-latency-only behavior from `GeneralSettings` instead of `config()`.
- `APP_TIMEZONE` and `DISPLAY_TIMEZONE` now fall back to the standard `TZ` env var when unset, before defaulting to UTC.
- Consolidated chart-related config keys into `config/speedtest.php` (previously split between `config/app.php` and `config/speedtest.php`)
- Renamed `default_chart_range_days` (env `DEFAULT_CHART_RANGE_DAYS`) to `chart_default_range_days` (env `CHART_DEFAULT_RANGE_DAYS`) for naming consistency with the other chart settings.

## 📷 Screenshots

<img width="1282" height="525" alt="Scherm­afbeelding 2026-08-25 om 20 27 20" src="https://github.com/user-attachments/assets/0159dab7-0ce6-4fcb-a6ce-67e29dac4b71" />
